### PR TITLE
Feature/156471564/paragraph basic text

### DIFF
--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -27,7 +27,7 @@ content:
   field_paragraph:
     type: entity_reference_revisions_entity_view
     weight: 102
-    label: above
+    label: hidden
     settings:
       view_mode: default
       link: ''
@@ -36,4 +36,6 @@ content:
   links:
     weight: 101
     region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -781,9 +781,9 @@ $settings['entity_update_batch_size'] = 50;
  * Keep this code block at the end of this file to take full effect.
  */
 #
-# if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
-#   include $app_root . '/' . $site_path . '/settings.local.php';
-# }
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}
 $config_directories['sync'] = '../config/sync';
 
 try {

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -804,3 +804,4 @@ try {
 } catch(Exception $e) {
   echo $e->getMessage();
 }
+$settings['install_profile'] = 'standard';

--- a/web/themes/custom/move_mil/scss/components/organisms/_paragraph--type--basic-text.scss
+++ b/web/themes/custom/move_mil/scss/components/organisms/_paragraph--type--basic-text.scss
@@ -1,0 +1,6 @@
+.paragraph--type--basic-text {
+  .field--name-field-plain-title {
+    font-weight: $font-bold;
+    font-size: 1.8rem;
+  }
+}

--- a/web/themes/custom/move_mil/scss/uswds.scss
+++ b/web/themes/custom/move_mil/scss/uswds.scss
@@ -5,6 +5,8 @@
 @import "../node_modules/uswds/src/stylesheets/uswds.scss";
 
 // components
-@import "components/archive-banner";
-@import "components/usa-header-extended";
-@import "components/usa-nav";
+// @import "components/archive-banner";
+// @import "components/usa-header-extended";
+// @import "components/usa-nav";
+
+@import "components/**/*";


### PR DESCRIPTION
This PR captures some basic changes to match the live move.mil theme for basic text paragraphs. Most of the styles are drawn from the uswds defaults, but we did have to customize treatment of the title field.

One small config change is also included. The paragraphs wrapper field on all pages had the label ("paragraph") appearing on the page, and the change simply hides that label.

Finally, I included a couple settings.php tweaks to facilitate local development that we'd thought had been previously added, but are not on the dev branch at present.

Ran lint and build with no errors.

Local example of a laid-out basic text paragraph, drawn from a [section on the live site](https://www.move.mil/moving-guide/oconus#pets):

<img width="978" alt="screen shot 2018-04-03 at 1 44 50 pm" src="https://user-images.githubusercontent.com/29130580/38266345-78a5c0b4-3746-11e8-8232-cfb5fa781248.png">
