### PR TITLE
updated our classes to be more america(usa)

### DIFF
--- a/web/themes/custom/move_mil/scss/03-organisms/_paragraph--text-with-image.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_paragraph--text-with-image.scss
@@ -7,7 +7,7 @@
     flex-direction: row;
   }
 
-  .image-title { // this is a class associated with an image or a title that gets aligned
+  .usa-media_block-img { // this is a class associated with an image or a title that gets aligned
     margin: 0 0 $spacing-medium 0;
 
     &__align-right {
@@ -32,7 +32,7 @@
     }
   }
 
-  .content {
+  .usa-media_block-body {
     margin: 0 0 $spacing-medium 0;
 
     &.usa-width-two-thirds {

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
@@ -1,8 +1,6 @@
 {%
   set classes = [
-    'paragraph', 'paragraph--text-with-image',
-    'paragraph--type--' ~ paragraph.bundle|clean_class,
-    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    'article-section', 'paragraph--text-with-image', 'usa-media_block'
   ]
 %}
 
@@ -15,11 +13,11 @@
       {% endif %}
         {# pass through our alignment value #}
         <div class="paragraph--text-with-image__align-{{content.field_image_alignment[0]['#markup']}}">
-          <div class="image-title image-title__align-{{content.field_image_alignment[0]['#markup']}} usa-width-one-third">
+          <div class="usa-media_block-img usa-media_block-img__align-{{content.field_image_alignment[0]['#markup']}} usa-width-one-third">
             {{ content.field_plain_title }}
             {{ content.field_image }}
           </div>
-          <div class="content content__align-{{content.field_image_alignment[0]['#markup']}} usa-width-two-thirds">
+          <div class="usa-media_block-body usa-media_block-body__align-{{content.field_image_alignment[0]['#markup']}} usa-width-two-thirds">
             {{ content.field_title_link }}
             {{ content.field_body }}
           </div>


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- updates the classes in our template and partial to include 
usa-media_block
usa-media_block-body
usa-media_block-img

## Testing

To verify the changes proposed in this pull request…
1. Pull these changes locally
2. in the custom theme directory, npm run build
3. create a new basic page content
4. give it a title
5. add the Text w/Image Paragraph

**Test A**

- give it a title
- include a logo w/alt text
- set image alignment to left
- include markup in the WYSIWYG editor
   - paragraph
   - unordered list of external links

## Screenshots

should still match the previous look and functionality

<img width="955" alt="screen shot 2018-04-04 at 11 11 14 am" src="https://user-images.githubusercontent.com/37077057/38328858-fef98d3e-3819-11e8-8859-af7c9554bb26.png">
