### PR TITLE
updated our protip alignment field, template, and  styles partial

### DIFF
--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--pro-tip.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--pro-tip.scss
@@ -1,5 +1,4 @@
-.paragraph--pro-tip,
-.usa-media_block {
+.paragraph--pro-tip {
 
   > div {
     padding: $spacing-small;
@@ -9,20 +8,22 @@
   &__align-right {
     margin: $spacing-medium 0;
 
-    @include media($medium-screen) {
-      float: right;
-      width: 35%;
-      margin: 0 0 0 $spacing-medium;
+    &.usa-width-one-third {
+      @include media($medium-screen) {
+        float: right;
+        margin: 0 0 0 $spacing-medium;
+      }
     }
   }
 
   &__align-left {
     margin: $spacing-medium 0;
 
-    @include media($medium-screen) {
-      float: left;
-      width: 35%;
-      margin: 0 $spacing-medium 0 0;
+    &.usa-width-one-third {
+      @include media($medium-screen) {
+        float: left;
+        margin: 0 $spacing-medium 0 0;
+      }
     }
   }
 

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--pro-tip.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--pro-tip.html.twig
@@ -7,8 +7,11 @@
   {% block paragraph %}
     <div{{ attributes.addClass(classes) }} >
       {% block content %}
+
+        {% set alignment = content.field_protip_alignment[0]['#markup'] %}
+
         {% if uswds_grid_class %}
-          <div class="{{ uswds_grid_class }} paragraph--pro-tip__align-{{ content.field_protip_image_alignment[0]['#markup']}}">
+          <div class="{{ uswds_grid_class }} paragraph--pro-tip__align-{{ alignment }} {% if alignment == 'right' or alignment == 'left' %}usa-width-one-third{% endif %}">
           {% endif %}
 
           <img class="usa-media_block-img" src="/themes/custom/move_mil/assets/img/icon--pro-tip.svg" alt="light bulb icon"></img>


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- updates our left/right alignments to use usa-one-third class rather than 35%
- removes usa-media-block as a parent class
- and sets alignment based on the selected value in the admin content form

## Testing

To verify the changes proposed in this pull request…

1. Pull these changes locally
2. cd /move-mil/web/themes/custom/move_mil
3. npm run build
4. create a basic page with varying pro-tips(selected alignments) and basic-text paragraphs to mimic the following view

![screencapture-move-mil-localhost-8000-node-2-2018-04-10-17_20_55](https://user-images.githubusercontent.com/37077057/38584437-48b3ba2a-3ce4-11e8-8a5b-4352314c227f.png)