### PR TITLE
initial templating and styles for SINGLE tabular data paragraph

### DIFF
--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--tabular-data.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--tabular-data.scss
@@ -1,0 +1,58 @@
+.paragraph--type--tabular-data {
+  @media screen and (max-width: $medium-screen) {
+    td,
+    th {
+      // border-top: none;
+      display: block;
+    }
+
+    th {
+      align-items: center;
+      display: flex;
+    }
+
+    td {
+      border-top: none;
+    }
+
+    // tr:first-child th {
+    //   border-top: 1px solid $color-gray;
+    // }
+
+    img {
+      margin-right: $site-margins-mobile;
+    }
+  }
+
+  .tabular-data-left {
+    vertical-align: top;
+
+    @include media($medium-screen) {
+      text-align: center;
+
+      img {
+        display: block;
+        margin: 0 auto 1rem auto;
+      }
+    }
+
+    .field--name-field-table-image-title {
+      @include h4();
+      @include margin(0 null);
+    }
+
+    .field--name-field-table-image-subtitle {
+      font-style: italic;
+      font-size: $h5-font-size;
+    }
+  }
+
+  .tabular-data-right {
+    .field--name-field-plain-title {
+      @include h3();
+      border-bottom: 0.125rem solid $color-gray-light;
+      margin-bottom: $site-margins-mobile;
+      padding-bottom: $site-margins-mobile;
+    }
+  }
+}

--- a/web/themes/custom/move_mil/templates/system/field/field--paragraph--field-table-image-title--tabular-data.html.twig
+++ b/web/themes/custom/move_mil/templates/system/field/field--paragraph--field-table-image-title--tabular-data.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% for item in items %}
+  <h3{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</h3>
+{% endfor %}

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--tabular-data.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--tabular-data.html.twig
@@ -1,0 +1,40 @@
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes).setAttribute('id', 'paragraph-'~paragraph.id.value) }}>
+    {% block content %}
+
+      {% if uswds_grid_class %}
+      <div class="{{ uswds_grid_class }}">
+      {% endif %}
+
+      <table>
+        <tbody>
+          <tr>
+            <th scope="row" class="tabular-data-left">
+              {{content.field_tabular_image}}
+              <div class="field-image-title-subtitle">
+                {{content.field_table_image_title}}
+                {{content.field_table_image_subtitle}}
+              </div>
+            </th>
+            <td class="tabular-data-right">
+              {{content.field_plain_title}}
+              {{content.field_body}}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      {% if uswds_grid_class %}
+      </div>
+      {% endif %}
+
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Executes Pivotal ticket https://www.pivotaltracker.com/story/show/156471638

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Refactors template for tabular data paragraph to make it an HTML table, somewhat matching live site. However, the table only covers a single paragraph, which in turn covers a *row* of the table. We might need to revisit this setup in a future sprint.
- Integrates tablular data styles used in live site.

## Testing

To verify the changes proposed in this pull request…

1. pull code
1. run `npm run build` from theme folder to compile css updates
1. go to "/entitlements" in local environment to verify theming

## Screenshots

Local environment with implemented theming:
<img width="1093" alt="screen shot 2018-04-12 at 10 13 01 am" src="https://user-images.githubusercontent.com/29130580/38682898-34a6c700-3e3a-11e8-844f-df3c614485de.png">
