### PR TITLE
Paragraphs config cleanup to unbreak tabular data

### DIFF
--- a/config/sync/field.field.node.page.field_paragraph.yml
+++ b/config/sync/field.field.node.page.field_paragraph.yml
@@ -5,11 +5,10 @@ dependencies:
   config:
     - field.storage.node.field_paragraph
     - node.type.page
-    - paragraphs.paragraphs_type.tabular_data
-    - paragraphs.paragraphs_type.tutorial_slideshow_image
     - paragraphs.paragraphs_type.basic_text
     - paragraphs.paragraphs_type.callout_accordion
     - paragraphs.paragraphs_type.pro_tip
+    - paragraphs.paragraphs_type.tabular_data_wrapper
     - paragraphs.paragraphs_type.text_with_image
     - paragraphs.paragraphs_type.warning_callout_box
   module:
@@ -27,46 +26,14 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    negate: 1
-    target_bundles:
-      tabular_data: tabular_data
-      tutorial_slideshow_image: tutorial_slideshow_image
-    target_bundles_drag_drop:
-      basic_text:
-        weight: 10
-        enabled: false
-      callout_accordion:
-        weight: 11
-        enabled: false
-      customer_service_box:
-        weight: 12
-        enabled: false
-      pro_tip:
-        weight: 13
-        enabled: false
-      tabular_data:
-        enabled: true
-        weight: 14
-      tabular_data_wrapper:
-        weight: 15
-        enabled: false
-      text_with_image:
-        weight: 16
-        enabled: false
-      tutorial_slideshow_image:
-        enabled: true
-        weight: 17
-      warning_callout_box:
-        weight: 18
-        enabled: false
     negate: 0
     target_bundles:
       basic_text: basic_text
       callout_accordion: callout_accordion
       pro_tip: pro_tip
-      tabular_data: tabular_data
       text_with_image: text_with_image
       warning_callout_box: warning_callout_box
+      tabular_data_wrapper: tabular_data_wrapper
     target_bundles_drag_drop:
       basic_text:
         enabled: true
@@ -81,8 +48,8 @@ settings:
         enabled: true
         weight: -14
       tabular_data:
-        enabled: true
         weight: -13
+        enabled: false
       text_with_image:
         enabled: true
         weight: -12
@@ -92,4 +59,7 @@ settings:
       warning_callout_box:
         enabled: true
         weight: -10
+      tabular_data_wrapper:
+        enabled: true
+        weight: 15
 field_type: entity_reference_revisions


### PR DESCRIPTION
Triage from merge conflicts this morning. Corrects which paragraph types should be allowed in that field on basic pages.

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Adds tabular data wrapper and removes tabular data from allowed paragraph types that can be added on basic pages.

## Testing

To verify the changes proposed in this pull request…

1. Pull code and import config
1. Go to your local and try to add a tabular data item on the Entitlements page.