### PR TITLE
Section dividers (tied to jump link targets)

### DIFF
--- a/web/themes/custom/move_mil/scss/01-atoms/_blockquote.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_blockquote.scss
@@ -9,7 +9,7 @@ blockquote {
     }
 
     &:last-child:after {
-      content: '”'
+      content: '”';
     }
 
     &:first-child:before, &:last-child:after {

--- a/web/themes/custom/move_mil/scss/01-atoms/_jump-link-section-divider.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_jump-link-section-divider.scss
@@ -1,0 +1,12 @@
+.field--name-field-paragraph {
+  .field__item:not(:first-child) {
+    .paragraph--type--basic-text {
+      .field--name-field-plain-title {
+        // line & spacing above for section dividers
+        padding-top: 2rem;
+        margin-top: 2rem;
+        border-top: 1px solid $color-cool-blue-lightest;
+      }
+    }
+  }
+}

--- a/web/themes/custom/move_mil/scss/01-atoms/_nightmare-moves-title-icons.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_nightmare-moves-title-icons.scss
@@ -19,14 +19,14 @@
       .field--name-field-plain-title {
         &:before {
           display: block;
-          @include margin(0 auto 2rem);
+          margin: 0 auto 2rem;
         }
 
         @include media($medium-screen) {
           &:before {
             display: inline-block;
             vertical-align: middle;
-            @include margin(0 1rem 0 0);
+            margin: 0 1rem 0 0;
           }
         }
       }

--- a/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
@@ -4,8 +4,6 @@
 
     //main content paragraphs
     > div.field__item:nth-child(2n-1) {
-
-
       @include media($medium-large-screen) {
         clear: both;
         float: left;

--- a/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
@@ -2,32 +2,55 @@
   .field--name-field-paragraph {
     @include clearfix;
 
-    //main content paragraphs
-    > div.field__item:nth-child(2n-1) {
-      @include media($medium-large-screen) {
-        clear: both;
-        float: left;
-        width: 62%;
-        margin-right: 3%;
-      }
+    .paragraph--pro-tip .usa-width-one-third {
+      float: none;
+      margin: 0;
+      width: 100%;
     }
 
-    // pro tips callouts
-    > div.field__item:nth-child(2n) {
-      .paragraph--pro-tip .usa-width-one-third {
-        float: none;
-        margin: 0;
-        width: 100%;
-      }
+    @include media($medium-large-screen) {
+      > div.field__item {
 
-      @include media($medium-large-screen) {
-        float: right;
-        width: 35%;
+        //main content paragraphs
+        &:nth-child(2n-1) {
+          clear: both;
+          float: left;
+          width: 62%;
+          margin-right: 3%;
+        }
 
-        .paragraph--pro-tip .usa-width-one-third {
-          float: none;
-          margin: 0;
-          width: 100%;
+        // pro tips callouts
+        &:nth-child(2n) {
+          float: right;
+          width: 35%;
+        }
+
+        &:nth-child(n+3) {
+          margin-top: 4rem;
+
+          // clean up section dividers
+          .paragraph--type--basic-text {
+            margin-top: 0;
+
+            &:before {
+              content: '';
+              position: absolute;
+              left: 0;
+              padding-right: 100%;
+              margin-top: -2rem;
+              border-top: 1px solid $color-cool-blue-lightest;
+            }
+
+            .field--name-field-plain-title {
+              padding-top: 0;
+              margin-top: 0;
+              border-top: 0;
+            }
+          }
+        }
+
+        &:nth-child(-n+2) {
+          margin-top: 2rem;
         }
       }
     }


### PR DESCRIPTION
We're going to need to revisit cases where sections and their dividers aren't so neatly tied to jump links, not to mention cases where the jump links currently differ from the live site.

But going with a general rule that the sections delineated by jump links have a light gray divider between them, the contents of this PR should be able to cover much of the spacing between/around page sections.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Except for the first paragraph on the page, puts 20px padding, 1px border (aka the section divider) and 20px margin above the title fields of Basic Text paragraphs (the specific fields referenced in the jump links module). 
- Creates a special snowflake override to mimic the divider behavior on the Nightmare Moves page, which has Basic Text and Pro Tips paragraphs together in a grid sort of layout. No other overrides are needed at this time, though that may change sooner rather than later as content becomes better-aligned with jump links generation.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Build theme assets
1. Browse various pages, mostly within Moving Guide section, to see the dividers and how they differ across pages.

## Screenshots

Local (CONUS page):
([compare to live site](https://www.move.mil/moving-guide/conus#assignment))
<img width="881" alt="screen shot 2018-04-19 at 3 44 26 pm" src="https://user-images.githubusercontent.com/29130580/39014565-b2f67ca0-43e8-11e8-89cb-af0b21d3ba80.png">

Local (Nightmare moves page):
([compare to live site](https://www.move.mil/moving-guide/nightmare-moves#bolt-box))
<img width="838" alt="screen shot 2018-04-19 at 3 45 55 pm" src="https://user-images.githubusercontent.com/29130580/39014602-d0147a08-43e8-11e8-93dd-28a52ef7d029.png">
