### PR TITLE
Build sign in banner

### DIFF
--- a/config/sync/block.block.at_your_destination.yml
+++ b/config/sync/block.block.at_your_destination.yml
@@ -13,7 +13,7 @@ dependencies:
 id: at_your_destination
 theme: move_mil
 region: content
-weight: 2
+weight: 1
 provider: null
 plugin: 'views_block:faqs-block_8'
 settings:

--- a/config/sync/block.block.during_the_move.yml
+++ b/config/sync/block.block.during_the_move.yml
@@ -13,7 +13,7 @@ dependencies:
 id: during_the_move
 theme: move_mil
 region: content
-weight: 1
+weight: 0
 provider: null
 plugin: 'views_block:faqs-block_7'
 settings:

--- a/config/sync/block.block.faq_section_after_the_move.yml
+++ b/config/sync/block.block.faq_section_after_the_move.yml
@@ -13,7 +13,7 @@ dependencies:
 id: faq_section_after_the_move
 theme: move_mil
 region: content
-weight: -1
+weight: -2
 provider: null
 plugin: 'views_block:faqs-block_5'
 settings:

--- a/config/sync/block.block.faq_section_before_you_move.yml
+++ b/config/sync/block.block.faq_section_before_you_move.yml
@@ -13,7 +13,7 @@ dependencies:
 id: faq_section_before_you_move
 theme: move_mil
 region: content
-weight: -5
+weight: -6
 provider: null
 plugin: 'views_block:faqs-block_1'
 settings:

--- a/config/sync/block.block.faq_section_delivery.yml
+++ b/config/sync/block.block.faq_section_delivery.yml
@@ -13,7 +13,7 @@ dependencies:
 id: faq_section_delivery
 theme: move_mil
 region: content
-weight: -2
+weight: -3
 provider: null
 plugin: 'views_block:faqs-block_4'
 settings:

--- a/config/sync/block.block.faq_section_moving_day.yml
+++ b/config/sync/block.block.faq_section_moving_day.yml
@@ -13,7 +13,7 @@ dependencies:
 id: faq_section_moving_day
 theme: move_mil
 region: content
-weight: -4
+weight: -5
 provider: null
 plugin: 'views_block:faqs-block_2'
 settings:

--- a/config/sync/block.block.faq_section_travel_tips.yml
+++ b/config/sync/block.block.faq_section_travel_tips.yml
@@ -13,7 +13,7 @@ dependencies:
 id: faq_section_travel_tips
 theme: move_mil
 region: content
-weight: -3
+weight: -4
 provider: null
 plugin: 'views_block:faqs-block_3'
 settings:

--- a/config/sync/block.block.jumplinks.yml
+++ b/config/sync/block.block.jumplinks.yml
@@ -4,12 +4,13 @@ status: true
 dependencies:
   module:
     - jumplink
+    - system
   theme:
     - move_mil
 id: jumplinks
 theme: move_mil
-region: content
-weight: -7
+region: sidebar_first
+weight: -11
 provider: null
 plugin: jumplinks
 settings:
@@ -17,4 +18,9 @@ settings:
   label: Jumplinks
   provider: jumplink
   label_display: '0'
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: true
+    context_mapping: {  }

--- a/config/sync/block.block.move_mil_content.yml
+++ b/config/sync/block.block.move_mil_content.yml
@@ -11,7 +11,7 @@ _core:
 id: move_mil_content
 theme: move_mil
 region: content
-weight: -6
+weight: -7
 provider: null
 plugin: system_main_block
 settings:

--- a/config/sync/block.block.move_mil_tools.yml
+++ b/config/sync/block.block.move_mil_tools.yml
@@ -13,7 +13,7 @@ _core:
 id: move_mil_tools
 theme: move_mil
 region: sidebar_first
-weight: -12
+weight: -10
 provider: null
 plugin: 'system_menu_block:tools'
 settings:

--- a/config/sync/block.block.prepping_the_move.yml
+++ b/config/sync/block.block.prepping_the_move.yml
@@ -13,7 +13,7 @@ dependencies:
 id: prepping_the_move
 theme: move_mil
 region: content
-weight: 0
+weight: -1
 provider: null
 plugin: 'views_block:faqs-block_6'
 settings:

--- a/web/themes/custom/move_mil/scss/01-atoms/_back-to-top.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_back-to-top.scss
@@ -1,15 +1,17 @@
-.back-to-top {
+.usa-section > .back-to-top {
   float: right;
-  margin-top: 0.5rem;
+  margin-top: 0;
   position: -webkit-sticky;
   position: sticky;
   top: 1rem;
   z-index: 1000;
 
-  .breadcrumbs + & {
-    @include media($nav-width) {
-      margin-top: -3.75rem;
-    }
+  @include media($small-screen) {
+    margin-top: 7rem;
+  }
+
+  @include media($nav-width) {
+    margin-top: 0;
   }
 
   a {

--- a/web/themes/custom/move_mil/scss/02-molecules/_breadcrumbs.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_breadcrumbs.scss
@@ -1,6 +1,44 @@
 .usa-breadcrumbs {
+  font-size: 1.4rem;
+  padding: 1rem 0;
+  position: relative;
+
+  &:before {
+    content: '';
+    position: absolute;
+    left: -9999px;
+    right: -9999px;
+    top: 0;
+    bottom: 0;
+    background-color: $color-gray-cool-light;
+    z-index: -1;
+  }
+
+  &:after {
+    content: none;
+  }
+
+  + div {
+    clear: both;
+  }
+
+  @include media($nav-width) {
+    padding: 0;
+
+    &:before {
+      content: none;
+    }
+
+    &:after {
+      content: '';
+    }
+  }
 
   li {
+
+    &.usa-nav-secondary-links {
+      margin-top: 0;
+    }
 
     a {
       margin: 0 !important;

--- a/web/themes/custom/move_mil/scss/02-molecules/_login-banner.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_login-banner.scss
@@ -1,0 +1,42 @@
+.login-banner {
+  background-color: $color-gray-cool-light;
+  color: $color-primary;
+  display: none;
+  padding: 1rem 0;
+
+  @include media($nav-width) {
+    display: block;
+  }
+
+  .homepage-login-banner & {
+    background-color: $color-green-light;
+    color: $color-white;
+    display: block;
+
+    a {
+      color: $color-white;
+    }
+
+    @include media($nav-width) {
+      font-size: $h3-font-size;
+      padding: 2rem 0;
+    }
+  }
+}
+
+.login-banner-text {
+  @include outer-container();
+  @include padding(null $site-margins-mobile);
+  font-size: $small-font-size;
+  max-width: $site-max-width;
+  text-align: center;
+
+  @include media($medium-screen) {
+    font-size: $base-font-size;
+  }
+
+  @include media($nav-width) {
+    @include padding(null $site-margins);
+    text-align: left;
+  }
+}

--- a/web/themes/custom/move_mil/scss/03-organisms/_block-jumplinks.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_block-jumplinks.scss
@@ -1,25 +1,9 @@
 .block-jumplinks {
-  float: left;
-  width: 100%;
-
-  + .block-system-main-block {
-    float: left;
-    width: 100%;
-  }
-
   .jumplinks-mobile-header {
     margin-bottom: 0.5rem;
   }
 
   @include media($sidenav-screen-width) {
-    padding-top: 1.5rem;
-    width: 20%;
-    margin-right: 5%;
-
-    + .block-system-main-block {
-      width: 75%;
-    }
-
     .jumplinks-mobile-header {
       display: none;
     }

--- a/web/themes/custom/move_mil/scss/03-organisms/_left-sidebar-layout.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_left-sidebar-layout.scss
@@ -1,0 +1,23 @@
+aside.usa-width-one-fourth {
+  float: left;
+  width: 100%;
+
+  + .region-content.usa-width-three-fourths {
+    float: left;
+    width: 100%;
+  }
+
+  @include media($sidenav-screen-width) {
+    padding-top: 1.5rem;
+    width: 20%;
+    margin-right: 5%;
+
+    &:nth-child(2n) {
+      margin-right: 5%;
+    }
+
+    + .region-content.usa-width-three-fourths {
+      width: 75%;
+    }
+  }
+}

--- a/web/themes/custom/move_mil/scss/03-organisms/_left-sidebar-layout.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_left-sidebar-layout.scss
@@ -20,4 +20,10 @@ aside.usa-width-one-fourth {
       width: 75%;
     }
   }
+
+  @include media($large-screen) {
+    &:nth-child(2n) {
+      width: 20%;
+    }
+  }
 }

--- a/web/themes/custom/move_mil/scss/03-organisms/_left-sidebar-layout.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_left-sidebar-layout.scss
@@ -27,3 +27,9 @@ aside.usa-width-one-fourth {
     }
   }
 }
+
+.usa-width-three-fourths {
+  @include media($large-screen) {
+    width: 100%;
+  }
+}

--- a/web/themes/custom/move_mil/scss/03-organisms/_uswds-middle-section.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_uswds-middle-section.scss
@@ -1,0 +1,7 @@
+.usa-section.uswds-middle-section {
+  padding-top: 0;
+
+  @include media($medium-large-screen) {
+    padding-top: 1.5rem;
+  }
+}

--- a/web/themes/custom/move_mil/templates/layout/page.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page.html.twig
@@ -104,6 +104,9 @@
       </div>
       {% endif %}
 
+      {{ page.content.move_mil_local_tasks }}
+      {{ page.content.move_mil_page_title }}
+
     </div>
   </div>
 
@@ -118,7 +121,7 @@
     {% endif %}
 
     <div class="region-content {{ content_class }}">
-      {{ page.content }}
+      {{ page.content|without('move_mil_page_title', 'move_mil_local_tasks') }}
     </div>
 
     {% if page.sidebar_second %}

--- a/web/themes/custom/move_mil/templates/layout/page.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page.html.twig
@@ -115,9 +115,7 @@
 
 
     {% if page.sidebar_first %}
-    <aside class="region-sidebar-first usa-width-one-fourth">
       {{ page.sidebar_first }}
-    </aside>
     {% endif %}
 
     <div class="region-content {{ content_class }}">

--- a/web/themes/custom/move_mil/templates/layout/page.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page.html.twig
@@ -82,14 +82,21 @@
 </section>
 {% endif %}
 
+<div class="login-banner">
+  <div class="login-banner-text">
+    <a href="https://eta.sddc.army.mil/ETASSOPortal/default.aspx">Sign in to <abbr title="Defense Personal Property System">DPS</abbr></a> or <a href="https://eta.sddc.army.mil/dpsRegister/dodCustomer.aspx">create a new account</a> to schedule your move, update information, or complete the claims process.
+  </div>
+</div>
+
 <section class="usa-section uswds-middle-section {{ main_classes }}">
 
-  <div class="back-to-top">
-    <a href="#">Return to top</a>
-  </div>
+    <div class="back-to-top">
+      <a href="#">Return to top</a>
+    </div>
 
   <div class="usa-grid">
     <div class="usa-width-full">
+
       {{ page.breadcrumb }}
 
       {{ page.highlighted }}

--- a/web/themes/custom/move_mil/templates/system/block/block--jumplinks.html.twig
+++ b/web/themes/custom/move_mil/templates/system/block/block--jumplinks.html.twig
@@ -32,7 +32,11 @@
     'block-' ~ plugin_id|clean_class,
   ]
 %}
-<div{{ attributes.addClass(classes) }}>
-    <div class="jumplinks-mobile-header">Jump to:</div>
-    {{ content }}
-</div>
+{% if content.jumplinks is iterable %}
+  <aside class="region-sidebar-first usa-width-one-fourth">
+    <div{{ attributes.addClass(classes) }}>
+      <div class="jumplinks-mobile-header">Jump to:</div>
+      {{ content }}
+    </div>
+  </aside>
+{% endif %}

--- a/web/themes/custom/move_mil/templates/system/region/region--sidebar-first.html.twig
+++ b/web/themes/custom/move_mil/templates/system/region/region--sidebar-first.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+{%
+  set classes = [
+    'region',
+    'region-' ~ region|clean_class,
+  ]
+%}
+{% if content %}
+  <!-- <div{{ attributes.addClass(classes) }}> -->
+  {{ content }}
+  <!-- </div> -->
+{% endif %}

--- a/web/themes/custom/move_mil/templates/system/region/region--sidebar-first.html.twig
+++ b/web/themes/custom/move_mil/templates/system/region/region--sidebar-first.html.twig
@@ -19,7 +19,5 @@
   ]
 %}
 {% if content %}
-  <!-- <div{{ attributes.addClass(classes) }}> -->
   {{ content }}
-  <!-- </div> -->
 {% endif %}


### PR DESCRIPTION
Adds sign-in banner to interior pages and makes breadcrumb treatment more responsive. @scottqueen-bixal is adding the banner on the front page in a different PR.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Adds sign-in banner to interior pages
- makes breadcrumb treatment more responsive.

## Testing

To verify the changes proposed in this pull request…

1. _Describe testing step one._
1. _Describe testing step two._
1. _etc. etc. etc._

## Screenshots

### [Live site](https://www.move.mil/moving-guide/nightmare-moves)

Desktop width:
<img width="1133" alt="screen shot 2018-04-23 at 4 07 13 pm" src="https://user-images.githubusercontent.com/29130580/39150497-85e87314-4710-11e8-83cd-f15c1dd9b1d0.png">

Mobile width (no banner, shaded background on breadcrumbs):
<img width="780" alt="screen shot 2018-04-23 at 4 14 38 pm" src="https://user-images.githubusercontent.com/29130580/39150806-759d5f6e-4711-11e8-8933-50c725fa3b4a.png">
