### PR TITLE
updated styles and and template structure to set <button> and aria control to callout accordion by usa-accordion-content-pid

### DIFF
--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--callout-accordion.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--callout-accordion.scss
@@ -88,4 +88,12 @@
       color: #205493;
     }
   }
+
+  .usa-accordion-content {
+    background-color: $color-gray-cool-lightest;
+
+    @include media($medium-screen) {
+      display: none;
+    }
+  }
 }

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--callout-accordion.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--callout-accordion.html.twig
@@ -13,10 +13,13 @@
       {% endif %}
 
       {# at mobile #}
-      <button class="usa-accordion-button" aria-controls="{{ 'paragraph-'~paragraph.id.value }}" aria-expanded="false">
+      <button class="usa-accordion-button" aria-controls="{{('callout-accordion-paragraph-'~paragraph.id.value)}}" aria-expanded="false">
         <h2 class="callout-accordion--title">{{ content.field_callout_title }}</h2>
-        {{ content.field_callout_content }}
       </button>
+      <div class="usa-accordion-content" id="{{('callout-accordion-paragraph-'~paragraph.id.value)}}" aria-hidden="true">
+        {{ content.field_callout_content }}
+      </div>
+
 
       {# at desktop #}
       <div class="side-bar-callout">


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- accordion content was wrapped in the <button/> element and was performing native functionality to close based on the aria target. The work here corrects that by separating out the content to a different div and passing through specificity to the aria control id from our paragraphs

**Old behavior**

![bug-callout-accordion-fix-at-expanded](https://user-images.githubusercontent.com/37077057/39276903-2db8ca40-48b9-11e8-9594-8cf1dc9ca62f.gif)

**New behavior**

![callout-accordion-fix-at-expanded](https://user-images.githubusercontent.com/37077057/39276914-38867d50-48b9-11e8-843c-2d21c894081d.gif)

## Testing

To verify the changes proposed in this pull request…

1. pull locally
2. npm run build at the theme level
3. make cr
4. create custom paragraph block with callout accordion and basic text content (include a link)
5. place in second region <front>
6. navigate to the homepage
7. set window size to less than 900px
8 interacting with the accordion should behave has outlined above.