### PR TITLE
Feature 156691172 clean views listing

### DIFF
--- a/config/sync/views.view.comment.yml
+++ b/config/sync/views.view.comment.yml
@@ -1,6 +1,6 @@
 uuid: c0387d5e-6f3f-4d2b-b86f-f2b3d120b551
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - comment

--- a/config/sync/views.view.comments_recent.yml
+++ b/config/sync/views.view.comments_recent.yml
@@ -1,6 +1,6 @@
 uuid: c941a7f5-a453-4c73-97d6-7341ec51a65d
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - comment

--- a/config/sync/views.view.content_recent.yml
+++ b/config/sync/views.view.content_recent.yml
@@ -1,6 +1,6 @@
 uuid: c2cfe873-2dab-4c0f-b9e4-71f447e1b092
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - node

--- a/config/sync/views.view.frontpage.yml
+++ b/config/sync/views.view.frontpage.yml
@@ -1,6 +1,6 @@
 uuid: 2a825236-03a3-4cc0-a506-59850a2d27ae
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_view_mode.node.rss

--- a/config/sync/views.view.who_s_new.yml
+++ b/config/sync/views.view.who_s_new.yml
@@ -1,6 +1,6 @@
 uuid: 7fe646af-e7df-4f77-a16f-b7facab7344c
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - user

--- a/config/sync/views.view.who_s_online.yml
+++ b/config/sync/views.view.who_s_online.yml
@@ -1,6 +1,6 @@
 uuid: 8d802d19-7926-4271-822f-13805819b66b
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - user

--- a/web/themes/custom/move_mil/templates/content/node--tutorial.html.twig
+++ b/web/themes/custom/move_mil/templates/content/node--tutorial.html.twig
@@ -87,7 +87,6 @@
         <div aria-label="tutorial intro">{{ content.field_tutorial_intro }}</div>
         <h3 class="move-mil--tutorial__title--label">Tutorial</h3>
         <div class="move-mil--tutorial__title">{{ drupal_title() }}</div>
-        {# <div aria-label="tutorial intro">{{ content.field_tutorial_intro }}</div> #}
         <div class="carousel-gallery-nav">
           <div class="carousel-gallery-nav__items" aria-label="carousel buttons" aria-controls="carousel"></div>
           <button id="show-all-steps" class="show-all-steps" aria-label="show all steps"></button>


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- disables unused views

## Testing

To verify the changes proposed in this pull request…

1. pull changes locally
2. make cim
3. make cr
4. navigate to /admin/structure/views

ensure that only the following views are enabled
- content
- custom block library
- FAQs
- Files
- People
- Taxonomy term
- Watchdog

## Screenshots

admin view after CONFIG import

![screencapture-move-mil-localhost-8000-admin-structure-views-2018-04-30-11_09_13](https://user-images.githubusercontent.com/37077057/39434699-49b2e0a8-4c67-11e8-8e81-a64b13a89257.png)
