### PR TITLE
Jump links cleanup and refinement

### DIFF
--- a/web/themes/custom/move_mil/js/scrollFix.js
+++ b/web/themes/custom/move_mil/js/scrollFix.js
@@ -1,24 +1,26 @@
-// (function($) {
-//   var offsetJumpScroll = function() {
-//     var jumpLink = $('.jump-link a');
-//     jumpLink.click(function(e) {
-//       var href = $(this).attr('href');
-//
-//       console.log(href);
-//       e.preventDefault();
-//       var targetId = href.substring(1, href.length);
-//       var target = $("div[id*='" + targetId + "']");
-//       var offset = $(target).offset();
-//       offset.top -= 200;
-//       $('html, body').animate({
-//         scrollTop: offset.top,
-//         scrollLeft: 0
-//       }, 1000);
-//       return;
-//     });
-//   };
-//
-//   $(window).on('load', function() {
-//     offsetJumpScroll();
-//   });
-// })(jQuery);
+(function($) {
+  var offsetJumpScroll = function() {
+    var jumpLink = $('.jump-link a');
+    jumpLink.click(function(e) {
+      var href = $(this).attr('href');
+      if(href[0] === '#' || (href.indexOf(window.location.pathname) > -1 && href.indexOf('#') > -1)){
+        e.preventDefault();
+        var targetId = href.split('#')[1];
+        // var targetId = href.substring(1, href.length);
+        var target = $("div[id*='" + targetId + "']");
+        var offset = $(target).offset();
+        offset.top -= 200;
+        $('html, body').animate({
+          scrollTop: offset.top,
+          scrollLeft: 0
+        }, 1000);
+        window.location.hash = targetId;
+      }
+      return;
+    });
+  };
+
+  $(window).on('load', function() {
+    offsetJumpScroll();
+  });
+})(jQuery);

--- a/web/themes/custom/move_mil/js/scrollFix.js
+++ b/web/themes/custom/move_mil/js/scrollFix.js
@@ -1,22 +1,24 @@
-(function($) {
-  var offsetJumpScroll = function() {
-    var jumpLink = $('.jump-link a');
-    jumpLink.click(function(e) {
-      e.preventDefault();
-      var hrefRaw = $(this).attr('href');
-      href = hrefRaw.substring(1, hrefRaw.length);
-      var target = $("div[id*='" + href + "']");
-      var offset = $(target).offset();
-      offset.top -= 200;
-      $('html, body').animate({
-        scrollTop: offset.top,
-        scrollLeft: 0
-      }, 1000);
-      return;
-    });
-  };
-
-  $(window).on('load', function() {
-    offsetJumpScroll();
-  });
-})(jQuery);
+// (function($) {
+//   var offsetJumpScroll = function() {
+//     var jumpLink = $('.jump-link a');
+//     jumpLink.click(function(e) {
+//       var href = $(this).attr('href');
+//
+//       console.log(href);
+//       e.preventDefault();
+//       var targetId = href.substring(1, href.length);
+//       var target = $("div[id*='" + targetId + "']");
+//       var offset = $(target).offset();
+//       offset.top -= 200;
+//       $('html, body').animate({
+//         scrollTop: offset.top,
+//         scrollLeft: 0
+//       }, 1000);
+//       return;
+//     });
+//   };
+//
+//   $(window).on('load', function() {
+//     offsetJumpScroll();
+//   });
+// })(jQuery);

--- a/web/themes/custom/move_mil/scss/02-molecules/_field--name-field-page-intro-text.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_field--name-field-page-intro-text.scss
@@ -1,6 +1,6 @@
 .field--name-field-page-intro-text,
-.field--name-field-tutorial-intro // inclding our intro for tutorials
-{
+// inclding our intro for tutorials
+.field--name-field-tutorial-intro {
   background: $color-gray-cool-lightest;
 
   @include margin(2rem 0-$site-margins-mobile);

--- a/web/themes/custom/move_mil/scss/02-molecules/_jump-links.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_jump-links.scss
@@ -29,6 +29,11 @@
         color: $color-primary-darker;
         text-decoration: underline;
       }
+
+      &.usa-current {
+        border: none;
+        padding-left: 0;
+      }
     }
   }
 }

--- a/web/themes/custom/move_mil/scss/03-organisms/_block-jumplinks.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_block-jumplinks.scss
@@ -1,4 +1,4 @@
-.block-jumplinks {
+.block-jumplinks, .block-sidebar-menu {
   .jumplinks-mobile-header {
     margin-bottom: 0.5rem;
   }

--- a/web/themes/custom/move_mil/scss/04-pages/_customer-service.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_customer-service.scss
@@ -109,6 +109,7 @@
             border-radius: $border-radius;
             display: inline-block;
             clear: both;
+
             @include padding(0.3rem 0.75rem);
             margin-bottom: 1.5rem;
           }

--- a/web/themes/custom/move_mil/scss/_quick-fixes.scss
+++ b/web/themes/custom/move_mil/scss/_quick-fixes.scss
@@ -1,4 +1,4 @@
-.usa-alert-error {
+.user-logged-in .usa-alert-error {
   max-height: 15rem;
   border: 1px solid $color-black-light;
   overflow-y: scroll;

--- a/web/themes/custom/move_mil/templates/system/block/block--system-menu-block--sidebar-first.html.twig
+++ b/web/themes/custom/move_mil/templates/system/block/block--system-menu-block--sidebar-first.html.twig
@@ -29,22 +29,14 @@
   set classes = [
     'block',
     'block-' ~ configuration.provider|clean_class,
+    'block-sidebar-menu',
     'block-' ~ plugin_id|clean_class,
-    'block-' ~ label['#markup']|replace({'&amp;':'and'})|clean_class,
   ]
 %}
 
-{% if label['#markup'] %}
-  <div{{ attributes.addClass(classes).setAttribute('id', label['#markup']|replace({'&amp;':'and'})|clean_id) }}>
-{% else %}
-  <div{{ attributes.addClass(classes)}}>
-{% endif %}
-  {{ title_prefix }}
-  {% if label %}
-    <h2{{ title_attributes }}>{{ label }}</h2>
-  {% endif %}
-  {{ title_suffix }}
-  {% block content %}
+<aside class="region-sidebar-first usa-width-one-fourth">
+  <div{{ attributes.addClass(classes) }}>
+    <div class="jumplinks-mobile-header">Jump to:</div>
     {{ content }}
-  {% endblock %}
-</div>
+  </div>
+</aside>

--- a/web/themes/custom/move_mil/templates/system/block/block--views.html.twig
+++ b/web/themes/custom/move_mil/templates/system/block/block--views.html.twig
@@ -1,0 +1,51 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class,
+    'block-' ~ label['#markup']|clean_class,
+  ]
+%}
+
+
+{% if label['#markup'] %}
+  <div{{ attributes.addClass(classes).setAttribute('id', label['#markup']|clean_class) }}>
+{% else %}
+  <div{{ attributes.addClass(classes)}}>
+{% endif %}
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/web/themes/custom/move_mil/templates/system/menu/menu--sidebar-first.html.twig
+++ b/web/themes/custom/move_mil/templates/system/menu/menu--sidebar-first.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Override of system/menu.html.twig for a sidebar menu.
+ */
+#}
+
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, 0) }}
+
+{% macro menu_links(items, menu_level) %}
+  {% import _self as menus %}
+
+  <div class="section-jump-links">
+    {% if items %}
+
+      <div class="jump-links">
+        {% for item in items %}
+          <div class="jump-link">
+            <a href="{{ item.url }}" {% if item.in_active_trail %} class="usa-current"{% endif %}>
+              <span>{{ item.title }}</span>
+            </a>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--basic-text.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--basic-text.html.twig
@@ -8,7 +8,7 @@
 
 {% block paragraph %}
   {% if content.field_plain_title[0] %}
-    <div{{ attributes.addClass(classes).setAttribute('id', content.field_plain_title[0]['#context'].value|clean_class ) }}>
+    <div{{ attributes.addClass(classes).setAttribute('id', content.field_plain_title[0]['#context'].value|clean_id ) }}>
   {% else %}
     <div{{ attributes.addClass(classes).setAttribute('id', 'paragraph-'~paragraph.id.value) }}>
   {% endif %}

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--basic-text.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--basic-text.html.twig
@@ -1,0 +1,29 @@
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+  ]
+%}
+
+{% block paragraph %}
+  {% if content.field_plain_title[0] %}
+    <div{{ attributes.addClass(classes).setAttribute('id', content.field_plain_title[0]['#context'].value|clean_class ) }}>
+  {% else %}
+    <div{{ attributes.addClass(classes).setAttribute('id', 'paragraph-'~paragraph.id.value) }}>
+  {% endif %}
+    {% block content %}
+
+      {% if uswds_grid_class %}
+      <div class="{{ uswds_grid_class }}">
+      {% endif %}
+
+      {{ content }}
+
+      {% if uswds_grid_class %}
+      </div>
+      {% endif %}
+
+    {% endblock %}
+  </div>
+{% endblock paragraph %}

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--tabular-data.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--tabular-data.html.twig
@@ -6,7 +6,11 @@
   ]
 %}
 {% block paragraph %}
-  <div{{ attributes.addClass(classes).setAttribute('id', 'paragraph-'~paragraph.id.value) }}>
+  {% if content.field_table_image_title[0] %}
+    <div{{ attributes.addClass(classes).setAttribute('id', content.field_table_image_title[0]['#context'].value|clean_id ) }}>
+  {% else %}
+    <div{{ attributes.addClass(classes).setAttribute('id', 'paragraph-'~paragraph.id.value) }}>
+  {% endif %}
     {% block content %}
       <div class="tabular-data-left">
         {{content.field_tabular_image[0]}}

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
@@ -6,7 +6,11 @@
 
 {% block paragraph %}
 
+  {% if content.field_plain_title[0] %}
+  <div{{ attributes.addClass(classes).setAttribute('id', content.field_plain_title[0]['#context'].value|clean_id ) }}>
+  {% else %}
   <div {{ attributes.addClass(classes).setAttribute('id', 'paragraph-'~paragraph.id.value) }}>
+  {% endif %}
     {% block content %}
 
       {% if uswds_grid_class %}


### PR DESCRIPTION
This PR executes, in large part, two Pivotal stories regarding [special-case jump link theming](https://www.pivotaltracker.com/story/show/157224738) and [nicer-looking paragraph/block IDs to match to the jump links](https://www.pivotaltracker.com/story/show/156725132) It also builds upon [the related story to build those custom jump links](https://www.pivotaltracker.com/story/show/157233732).

**IMPACT:** The change to paragraph IDs breaks the current functionality of the jumplinks module, so an update to that module's logic will be necessary to get them working again. A handful of other content/config updates will also be necessary to fully align jump link functionality in the one-off cases, and Feld is prepared to take care of those updates once this PR is merged into the alpha site.

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Customizes paragraph IDs to match a machine-name version of the title field. As a fallback, each paragraph type affected keeps the paragraph ID as its jump link target ID, if the relevant field is left blank. Extends similar logic to view blocks to account for the two cases of  jump links associated with accordion section.
- Adds custom templating for the new sidebar menus generated by Feld (see alpha site) to match structure of jumplinks generated by the module
- Adds a few style changes to account for the new menus and a couple one-off oddities.
- Refines the jQuery logic creating a smooth scroll when clicking jump links and accounts for a couple unintended consequences of that logic.
- Addresses a couple minor sass linter warnings.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Compile theme assets
1. Grab a current db from the alpha site
1. Check behavior of jump links on each page specified in the Tasks of [this pivotal ticket](https://www.pivotaltracker.com/story/show/157233732) to identify further needs. It's possible that a few individual links will work, but likely not many.

## Screenshots
 *Note: ignore differences in the links themselves between local & live - I just didn't hand-enter all of them.

**Local - [Tutorials - Create a Shipment](http://move.mil.localhost:8000/tutorials/create-a-shipment):**
<img width="1105" alt="screen shot 2018-05-02 at 1 54 04 pm" src="https://user-images.githubusercontent.com/29130580/39540368-73e698ba-4e10-11e8-8074-8dd27b559900.png">

**Live Site - [Tutorials - Create a Shipment](https://www.move.mil/tutorials/create-a-shipment):**
<img width="1110" alt="screen shot 2018-05-02 at 1 55 55 pm" src="https://user-images.githubusercontent.com/29130580/39540455-b30b3da2-4e10-11e8-8877-136f50d0384d.png">
