### PR TITLE
Feature 157232981 implement ckui module in wysiwyg

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,19 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/templates",
+                "type": "drupal-library",
+                "version": "4.5.7",
+                "dist": {
+                    "type": "zip",
+                    "url": "http://download.ckeditor.com/templates/releases/templates_4.5.7.zip",
+                    "reference": "master"
+                }
+            }
         }
     ],
     "require": {
@@ -32,6 +45,7 @@
         "drupal/twig_field_value": "^1.1",
         "drupal/twig_tweak": "^1.9",
         "drupal/uswds": "^1.0@beta",
+        "drupal/wysiwyg_template": "^2.0@beta",
         "drush/drush": "^9.0.0",
         "phpoffice/phpspreadsheet": "^1.2",
         "vlucas/phpdotenv": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cb4a6b9c493c9ee47fee4839fdfcadd",
+    "content-hash": "03957c324fc4fd16fdfba73022e8e7f4",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -186,6 +186,17 @@
             ],
             "description": "Drupal code generator",
             "time": "2018-03-03T04:17:26+00:00"
+        },
+        {
+            "name": "ckeditor/templates",
+            "version": "4.5.7",
+            "dist": {
+                "type": "zip",
+                "url": "http://download.ckeditor.com/templates/releases/templates_4.5.7.zip",
+                "reference": "master",
+                "shasum": null
+            },
+            "type": "drupal-library"
         },
         {
             "name": "commerceguys/addressing",
@@ -2630,6 +2641,151 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/uswds",
                 "issues": "https://www.drupal.org/project/issues/uswds?categories=All"
+            }
+        },
+        {
+            "name": "drupal/wysiwyg_template",
+            "version": "2.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/wysiwyg_template",
+                "reference": "8.x-2.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/wysiwyg_template-8.x-2.0-beta1.zip",
+                "reference": "8.x-2.0-beta1",
+                "shasum": "eb6bd41d7a99487b0bea7ee0be82629c509aeed1"
+            },
+            "require": {
+                "ckeditor/templates": "4.5.7",
+                "drupal/core": "~8.0",
+                "drupal/wysiwyg_template_core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.0-beta1",
+                    "datestamp": "1499440442",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\wysiwyg_template\\": "src/"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "guybedford",
+                    "homepage": "https://www.drupal.org/user/746802"
+                },
+                {
+                    "name": "jenlampton",
+                    "homepage": "https://www.drupal.org/user/85586"
+                },
+                {
+                    "name": "jhedstrom",
+                    "homepage": "https://www.drupal.org/user/208732"
+                },
+                {
+                    "name": "jurgenhaas",
+                    "homepage": "https://www.drupal.org/user/168924"
+                },
+                {
+                    "name": "recidive",
+                    "homepage": "https://www.drupal.org/user/12564"
+                },
+                {
+                    "name": "sebas5384",
+                    "homepage": "https://www.drupal.org/user/567694"
+                },
+                {
+                    "name": "snipebin",
+                    "homepage": "https://www.drupal.org/user/858710"
+                }
+            ],
+            "description": "Manage templates for use in a WYSIWYG.",
+            "homepage": "https://www.drupal.org/project/wysiwyg_template",
+            "keywords": [
+                "Drupal",
+                "Templates",
+                "WYSIWYG"
+            ],
+            "support": {
+                "source": "https://drupal.org/project/wysiwyg_template",
+                "issues": "https://drupal.org/project/issues/wysiwyg_template"
+            }
+        },
+        {
+            "name": "drupal/wysiwyg_template_core",
+            "version": "2.0.0-beta1",
+            "require": {
+                "drupal/core": "~8.0",
+                "drupal/wysiwyg_template": "self.version"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.0-beta1",
+                    "datestamp": "1499440442",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "guybedford",
+                    "homepage": "https://www.drupal.org/user/746802"
+                },
+                {
+                    "name": "jenlampton",
+                    "homepage": "https://www.drupal.org/user/85586"
+                },
+                {
+                    "name": "jhedstrom",
+                    "homepage": "https://www.drupal.org/user/208732"
+                },
+                {
+                    "name": "jurgenhaas",
+                    "homepage": "https://www.drupal.org/user/168924"
+                },
+                {
+                    "name": "recidive",
+                    "homepage": "https://www.drupal.org/user/12564"
+                },
+                {
+                    "name": "sebas5384",
+                    "homepage": "https://www.drupal.org/user/567694"
+                },
+                {
+                    "name": "snipebin",
+                    "homepage": "https://www.drupal.org/user/858710"
+                }
+            ],
+            "description": "Core functionality for the WYSIWYG Template module",
+            "homepage": "https://www.drupal.org/project/wysiwyg_template",
+            "support": {
+                "source": "http://cgit.drupalcode.org/wysiwyg_template"
             }
         },
         {
@@ -8525,6 +8681,7 @@
         "drupal/node_class": 10,
         "drupal/stage_file_proxy": 15,
         "drupal/uswds": 10,
+        "drupal/wysiwyg_template": 10,
         "drupal/drupal-extension": 20
     },
     "prefer-stable": true,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -50,6 +50,8 @@ module:
   update: 0
   user: 0
   views_ui: 0
+  wysiwyg_template: 0
+  wysiwyg_template_core: 0
   extlink: 1
   menu_link_content: 1
   views: 10

--- a/config/sync/editor.editor.full_html.yml
+++ b/config/sync/editor.editor.full_html.yml
@@ -54,6 +54,10 @@ settings:
           name: Custom
           items:
             - Styles
+        -
+          name: Layouts
+          items:
+            - TemplateSelector
   plugins:
     language:
       language_list: un

--- a/config/sync/filter.format.full_html.yml
+++ b/config/sync/filter.format.full_html.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - editor
+    - wysiwyg_template_core
 _core:
   default_config_hash: hewPmBgni9jlDK_IjLxUx1HsTbinK-hdl0lOwjbteIY
 name: 'Full HTML'
@@ -43,3 +44,9 @@ filters:
       allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre>'
       filter_html_help: true
       filter_html_nofollow: false
+  filter_wysiwyg_cleanup:
+    id: filter_wysiwyg_cleanup
+    provider: wysiwyg_template_core
+    status: true
+    weight: 10
+    settings: {  }

--- a/config/sync/wysiwyg_template.settings.yml
+++ b/config/sync/wysiwyg_template.settings.yml
@@ -1,0 +1,3 @@
+library_path: libraries/templates
+_core:
+  default_config_hash: Ln-8c6U1Tq4kDhMD30VjO1h-GbXC7ZrVI_fYWkVVE2M

--- a/config/sync/wysiwyg_template.wysiwyg_template.1_4_column_layout.yml
+++ b/config/sync/wysiwyg_template.wysiwyg_template.1_4_column_layout.yml
@@ -1,0 +1,16 @@
+uuid: 50754d78-a0da-49a4-ac35-a8b4791eafc0
+langcode: en
+status: true
+dependencies: {  }
+id: 1_4_column_layout
+label: '1/4 column layout'
+description: ''
+body:
+  value: "<div class=\"usa-grid-full content-column-group\">\r\n<div class=\"usa-width-one-fourth content-column\">column 1: replace with your content</div>\r\n\r\n<div class=\"usa-width-one-fourth content-column\">column 2: replace with your content</div>\r\n\r\n<div class=\"usa-width-one-fourth content-column\">column 3: replace with your content</div>\r\n\r\n<div class=\"usa-width-one-fourth content-column\">column 4: replace with your content</div>\r\n</div>\r\n"
+  format: full_html
+weight: -10
+node_types:
+  - article
+  - faq
+  - page
+  - tutorial

--- a/config/sync/wysiwyg_template.wysiwyg_template.2_3_column_layout.yml
+++ b/config/sync/wysiwyg_template.wysiwyg_template.2_3_column_layout.yml
@@ -1,0 +1,16 @@
+uuid: 81540087-f9eb-4b76-b07d-7524fe95b2e9
+langcode: en
+status: true
+dependencies: {  }
+id: 2_3_column_layout
+label: '2/3 column layout'
+description: ''
+body:
+  value: "<div class=\"usa-grid-full content-column-group\">\r\n<div class=\"usa-width-two-thirds content-column\">column 1: replace with your content</div>\r\n\r\n<div class=\"usa-width-one-third content-column\">column 2: replace with your content</div>\r\n</div>\r\n"
+  format: full_html
+weight: -10
+node_types:
+  - article
+  - faq
+  - page
+  - tutorial

--- a/config/sync/wysiwyg_template.wysiwyg_template.2_col.yml
+++ b/config/sync/wysiwyg_template.wysiwyg_template.2_col.yml
@@ -1,0 +1,16 @@
+uuid: 81886649-fba0-4f5f-a846-632e1195daf9
+langcode: en
+status: true
+dependencies: {  }
+id: 2_col
+label: '1/2 Column Layout'
+description: ''
+body:
+  value: "<div class=\"usa-grid-full content-column-group\">\r\n<div class=\"usa-width-one-half content-column\">column 1: replace with your content</div>\r\n\r\n<div class=\"usa-width-one-half content-column\">column 2: replace with your content</div>\r\n</div>\r\n"
+  format: full_html
+weight: -10
+node_types:
+  - page
+  - article
+  - faq
+  - tutorial

--- a/config/sync/wysiwyg_template.wysiwyg_template.3_column_layout.yml
+++ b/config/sync/wysiwyg_template.wysiwyg_template.3_column_layout.yml
@@ -1,0 +1,16 @@
+uuid: 35a9acb5-a0f8-4fd0-a49b-72353a6b9255
+langcode: en
+status: true
+dependencies: {  }
+id: 3_column_layout
+label: '1/3 column layout'
+description: ''
+body:
+  value: "<div class=\"usa-grid-full content-column-group\">\r\n<div class=\"usa-width-one-third content-column\">column 1: replace with your content</div>\r\n\r\n<div class=\"usa-width-one-third content-column\">column 2: replace with your content</div>\r\n\r\n<div class=\"usa-width-one-third content-column\">column 3: replace with your content</div>\r\n</div>\r\n"
+  format: full_html
+weight: -10
+node_types:
+  - page
+  - article
+  - faq
+  - tutorial

--- a/web/themes/custom/move_mil/scss/01-atoms/_cke-columns.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_cke-columns.scss
@@ -4,7 +4,7 @@
 
     &.usa-grid-full {
       padding: 2%;
-      border: 1px solid lightgrey;
+      border: 1px solid $color-gray-light;
 
       .content-column {
         &.usa-width-one-half,
@@ -12,7 +12,7 @@
         &.usa-width-two-thirds,
         &.usa-width-one-fourth {
           padding: 2%;
-          border: 1px dotted lightgrey;
+          border: 1px dotted $color-gray-light;
           margin: 1rem 0;
         }
       }

--- a/web/themes/custom/move_mil/scss/01-atoms/_cke-columns.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_cke-columns.scss
@@ -1,0 +1,24 @@
+.cke_editable {
+
+  .content-column-group {
+
+    &.usa-grid-full {
+      padding: 2%;
+      border: 1px solid lightgrey;
+
+      .content-column {
+        &.usa-width-one-half,
+        &.usa-width-one-third,
+        &.usa-width-two-thirds,
+        &.usa-width-one-fourth {
+          padding: 2%;
+          border: 1px dotted lightgrey;
+          margin: 1rem 0;
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/web/themes/custom/move_mil/scss/01-atoms/_content-columns.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_content-columns.scss
@@ -1,0 +1,22 @@
+.content-column-group {
+
+  &.usa-grid-full {
+
+    > :first-child {
+      margin-top: 1em;
+      margin-bottom: 1em;
+    }
+
+    .content-column {
+
+      &.usa-width-one-half,
+      &.usa-width-one-third,
+      &.usa-width-one-fourth {
+        margin-top: 1em;
+        margin-bottom: 1em;
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- adds/enables a new module to work with the WYSIWYG API and creates 4 templates in the CKeditor, including;

  - 1/2 Column layout 
  - 1/3 column layout 
  - 1/4 column layout 
  - 2/3 column layout


## Testing

To verify the changes proposed in this pull request…

1. pull code locally
2. make composer
3. cd /move-mil/web/themes/custom/move_mil
4. npm run build
5. make cr
6 navigate to a "basic page" content type, ie. /moving-guide
7. edit the node and add a basic text paragraph type
8. select "Full HTML"
9. in the upper right hand side of the CKeditor select the template button 
<img width="32" alt="screen shot 2018-05-02 at 5 51 19 pm" src="https://user-images.githubusercontent.com/37077057/39551048-7b776e9e-4e31-11e8-9b91-c8aee51f1453.png">
10. select one of the content-column templates
<img width="422" alt="screen shot 2018-05-02 at 5 52 14 pm" src="https://user-images.githubusercontent.com/37077057/39551075-9861f524-4e31-11e8-8cf1-5344b93164fc.png">
11. replace placeholder content with new content, save 
<img width="875" alt="screen shot 2018-05-02 at 5 33 26 pm" src="https://user-images.githubusercontent.com/37077057/39551133-c5077dc4-4e31-11e8-9790-72ba24ae2dd8.png">

here is the content within tabular data updated with this new implementation and an example of all the templates at the bottom

![screencapture-move-mil-localhost-8000-moving-guide-2018-05-02-17_28_33](https://user-images.githubusercontent.com/37077057/39551219-18e0fa4c-4e32-11e8-8838-563b9c9639b0.png)

showing responsiveness across devices

![contentcolumnsresponsive](https://user-images.githubusercontent.com/37077057/39551334-a0371a1c-4e32-11e8-9b01-18e3de986b10.gif)


