### PR TITLE
back to top button and breadcrumbs area remediation

### DIFF
--- a/web/themes/custom/move_mil/scss/01-atoms/_back-to-top.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_back-to-top.scss
@@ -1,19 +1,21 @@
 .usa-section > .back-to-top {
+  //positioning & alignment
   float: right;
-  margin-top: 0;
   position: -webkit-sticky;
   position: sticky;
   top: 1rem;
+  margin-top: 1rem;
   z-index: 1000;
 
-  @include media($small-screen) {
-    margin-top: 7rem;
-  }
-
   @include media($nav-width) {
-    margin-top: 0;
+    margin-top: -2.7rem;
   }
 
+  + .usa-grid {
+    clear: both;
+  }
+
+  // internal button styles
   a {
     @include padding(0.75rem 1.5rem);
     background-color: $color-gold;
@@ -31,6 +33,7 @@
   }
 }
 
+// account for admin toolbar
 .user-logged-in.toolbar-fixed {
   .back-to-top {
     top: 4.9rem;

--- a/web/themes/custom/move_mil/scss/02-molecules/_breadcrumbs.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_breadcrumbs.scss
@@ -14,23 +14,11 @@
     z-index: -1;
   }
 
-  &:after {
-    content: none;
-  }
-
-  + div {
-    clear: both;
-  }
-
   @include media($nav-width) {
     padding: 0;
 
     &:before {
       content: none;
-    }
-
-    &:after {
-      content: '';
     }
   }
 

--- a/web/themes/custom/move_mil/templates/layout/page.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page.html.twig
@@ -90,31 +90,32 @@
 
 <section class="usa-section uswds-middle-section {{ main_classes }}">
 
-    <div class="back-to-top">
-      <a href="#">Return to top</a>
-    </div>
-
   <div class="usa-grid">
     <div class="usa-width-full">
-
       {{ page.breadcrumb }}
-
-      {{ page.highlighted }}
-
-      {% if page.help|render|trim %}
-      <div class="usa-alert usa-alert-info">
-        <div class="usa-alert-body">
-          <p class="usa-alert-text">
-            {{ page.help }}
-          </p>
-        </div>
-      </div>
-      {% endif %}
-
-      {{ page.content.move_mil_local_tasks }}
-      {{ page.content.move_mil_page_title }}
-
     </div>
+  </div>
+
+  <div class="back-to-top">
+    <a href="#">Back to top</a>
+  </div>
+
+  <div class="usa-grid">
+
+    {{ page.highlighted }}
+
+    {% if page.help|render|trim %}
+    <div class="usa-alert usa-alert-info">
+      <div class="usa-alert-body">
+        <p class="usa-alert-text">
+          {{ page.help }}
+        </p>
+      </div>
+    </div>
+    {% endif %}
+
+    {{ page.content.move_mil_local_tasks }}
+    {{ page.content.move_mil_page_title }}
   </div>
 
   <div class="uswds-main-content-wrapper {% if edge_to_edge == false %}usa-grid{% endif %}">


### PR DESCRIPTION
This PR is tied to a [new Pivotal ticket](https://www.pivotaltracker.com/story/show/157365939) capturing refinements needed to clean up the markup structure and css that was leading to a bug in some browsers. The issue with lots of blank space appearing after clicking a jump link (or scrolling down the page) and then scrolling back up should be fully fixed with this update in place. 

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Reorganizes the "Back to Top" button and the items around it (breadcrumbs, admin tasks, messages, page title) to more exactly match behavior on live site. 
- Corrects the text of the "Back to top" button (was "Return to top")
- Fixes an aesthetic annoyance on smaller browsers where the back to top button was crashing into the breadcrumbs, especially when the breadcrumbs break to multiple lines.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Build theme assets
1. Check out behavior of the back to top button in a variety of circumstances: scrolling up and down the page, clicking the button when scrolled down, different screen sizes, different pages (esp. ones with long breadcrumbs), different browsers (esp. Firefox, where the white space had been a more pervasive problem).

## Screenshots

Local (mobile size, long breadcrumbs):
![screen shot 2018-05-07 at 5 27 10 pm](https://user-images.githubusercontent.com/29130580/39726123-07aacb3e-521c-11e8-8235-4f77611de09c.png)

Live site (mobile size, [same page as above](https://www.move.mil/moving-guide/conus)):
![screen shot 2018-05-07 at 5 28 38 pm](https://user-images.githubusercontent.com/29130580/39726162-2ad6cc3e-521c-11e8-83df-ec79116a44d8.png)

 