### PR TITLE
Feature/157233561/theme icon jump links

### DIFF
--- a/web/themes/custom/move_mil/scss/02-molecules/_icon-links-grid-list.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_icon-links-grid-list.scss
@@ -1,5 +1,6 @@
 .icon-links-grid-list {
   position: relative;
+
   ul {
     @include unstyled-list;
     @include clearfix;
@@ -7,14 +8,16 @@
     li {
       float: left;
       width: 50%;
+
       @include padding(0.8rem 2rem);
 
-      &:nth-child(2n-1){
+      &:nth-child(2n-1) {
         clear: left;
       }
 
       @include media($medium-screen) {
         width: 25%;
+
         &:nth-child(2n-1) {
           clear: none;
         }

--- a/web/themes/custom/move_mil/scss/02-molecules/_icon-links-grid-list.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_icon-links-grid-list.scss
@@ -1,0 +1,95 @@
+.icon-links-grid-list {
+  position: relative;
+  ul {
+    @include unstyled-list;
+    @include clearfix;
+
+    li {
+      float: left;
+      width: 50%;
+      @include padding(0.8rem 2rem);
+
+      &:nth-child(2n-1){
+        clear: left;
+      }
+
+      @include media($medium-screen) {
+        width: 25%;
+        &:nth-child(2n-1) {
+          clear: none;
+        }
+      }
+
+      a {
+        display: block;
+        font-size: $small-font-size;
+        text-align: center;
+        text-decoration: none;
+
+        &:hover, &:focus, &:active {
+          text-decoration: underline;
+        }
+
+        img {
+          display: block;
+          margin: 0 auto 1.5rem auto;
+          height: 5rem;
+
+          @include media($medium-screen) {
+            height: 8rem;
+          }
+        }
+      }
+    }
+  }
+
+  &.special-items-links {
+    margin: 1.5rem 0 2rem;
+
+    ul {
+      @include display(flex);
+      @include flex-wrap(wrap);
+
+      li {
+        float: none;
+        width: 100%;
+        margin-bottom: $site-margins-mobile;
+
+        @include media($small-screen) {
+          width: 25%;
+        }
+
+        @include media($nav-width) {
+          width: 20%;
+        }
+
+        &.double-wide {
+          @include media($small-screen) {
+            width: 50%;
+          }
+
+          @include media($nav-width) {
+            width: 40%;
+          }
+        }
+
+        a {
+          font-weight: $font-bold;
+          font-size: $h5-font-size;
+
+          img {
+            height: auto;
+            width: auto;
+          }
+
+          i {
+            display: block;
+            font-style: italic;
+            font-weight: $font-normal;
+            color: $color-base;
+          }
+        }
+      }
+    }
+  }
+}

--- a/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
@@ -1,0 +1,8 @@
+.tools-resources {
+  margin-top: -2rem;
+
+  .field--name-field-page-intro-text {
+    background-color: $color-gray-cool-light;
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
Theming for the two special cases of grid-based jump links that include icons. Completes Pivotal stories for [the top of Tools & Resources](https://www.pivotaltracker.com/story/show/157233561) and [the Special Items section on Entitlements](https://www.pivotaltracker.com/story/show/156859279).

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Lays icon-and-text link items with an "icon-links-grid-list" wrapper class into a grid.
- Styles the individual link items to match the live site.
- Adds customization for the Entitlements special item links.
- Targets the Tools & Resources page to remove space above the blue Intro Text box

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Build theme assets
1. On site with updated content, visit Tools & Resources and Entitlements pages and compare the relevant sections to the versions on the live site. Should match (though potentially not exactly due to icon size differences) at all screen widths.

## Screenshots

### Local

Entitlements icons (desktop width):
<img width="796" alt="screen shot 2018-05-09 at 1 46 11 pm" src="https://user-images.githubusercontent.com/29130580/39830432-71458d3a-538f-11e8-80ed-2e62adcb6e40.png">

Tools & Resources (desktop width):
<img width="1039" alt="screen shot 2018-05-09 at 1 48 12 pm" src="https://user-images.githubusercontent.com/29130580/39830498-a6dacc3a-538f-11e8-9a01-65903ab2a3f5.png">

### Live site:

Entitlements icons (desktop width):
<img width="751" alt="screen shot 2018-05-09 at 1 47 19 pm" src="https://user-images.githubusercontent.com/29130580/39830461-87a5c536-538f-11e8-8baf-a17a199b00c4.png">

Tools & Resources (desktop width):
<img width="1025" alt="screen shot 2018-05-09 at 1 48 50 pm" src="https://user-images.githubusercontent.com/29130580/39830539-bbde192a-538f-11e8-9f0d-ecdb58f111f3.png">
