### PR TITLE
adapt mobile homepage jumplink targets to prettified target ids

### DIFF
--- a/web/themes/custom/move_mil/templates/layout/page--front.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page--front.html.twig
@@ -137,22 +137,22 @@
   <div class="homepage-anchor-title">Prepare for your best move yet.</div>
     <ul class="usa-unstyled-list homepage-anchor-list">
       <li>
-        <a href="#paragraph-358">{# id from paragraph in content #}
+        <a href="#plan-your-move">{# id from paragraph in content #}
           <img alt="Plan your move icon" src="/themes/custom/move_mil/images/icon--plan-your-move.svg">Plan
         </a>
       </li>
       <li>
-        <a href="#paragraph-359"> {# id from paragraph in content #}
+        <a href="#schedule-your-move"> {# id from paragraph in content #}
           <img alt="Schedule your move icon" src="/themes/custom/move_mil/images/icon--schedule-your-move.svg">Schedule
         </a>
       </li>
       <li>
-        <a href="#paragraph-360"> {# id from paragraph in content #}
+        <a href="#get-ready-for-moving-day"> {# id from paragraph in content #}
           <img alt="Get ready for moving day icon" src="/themes/custom/move_mil/images/icon--get-ready-for-moving-day.svg">Moving Day
         </a>
       </li>
       <li>
-        <a href="#paragraph-361"> {# id from paragraph in content #}
+        <a href="#settling-in"> {# id from paragraph in content #}
           <img alt="Settling in icon" src="/themes/custom/move_mil/images/icon--settling-in.svg">Settle In
         </a>
       </li>


### PR DESCRIPTION
This is a very simple fix........just adapting one last set of hardcoded jump links, this one with the targets entered into the home page template, to reference semantic paragraph ids. It'd be great to get this integrated within this sprint, if possible.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

-Edits four jump link paths in the home page template to match new paragraph ids

## Testing

To verify the changes proposed in this pull request…

1. Pull code and import config
1. Open homepage in mobile view
1. Click on each of the four jump link icons to test functionality 