### PR TITLE
A bunch of global spacing/layout/alignment triage

### DIFF
--- a/web/themes/custom/move_mil/scss/01-atoms/_content-columns.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_content-columns.scss
@@ -9,12 +9,25 @@
     }
 
     .content-column {
-
       &.usa-width-one-half,
       &.usa-width-one-third,
       &.usa-width-one-fourth {
         margin-top: 1em;
         margin-bottom: 1em;
+      }
+
+      ul, ol {
+        margin: 0;
+      }
+
+      &:not(:first-child) {
+        ul {
+          margin-top: -0.5em;
+
+          @include media($medium-screen) {
+            margin-top: 0;
+          }
+        }
       }
     }
 

--- a/web/themes/custom/move_mil/scss/01-atoms/_text-formatted.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_text-formatted.scss
@@ -1,0 +1,4 @@
+// WYSIWYG fields
+.field.text-formatted {
+  @include strip-paragraph-spacing();
+}

--- a/web/themes/custom/move_mil/scss/02-molecules/_field--name-field-paragraph.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_field--name-field-paragraph.scss
@@ -1,0 +1,7 @@
+.field--name-field-paragraph {
+  padding-top: 2.5rem;
+
+  .field--name-field-page-intro-text + & {
+    padding-top: 2rem;
+  }
+}

--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--callout-accordion.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--callout-accordion.scss
@@ -4,7 +4,7 @@
 
   h2.callout-accordion--title {
     padding: $spacing-medium 0 0;
-    margin: 0 $spacing-medium;
+    margin: 0 $spacing-medium 1.7rem;
     font-family: $font-sans;
     font-size: 1.7rem;
     font-weight: $font-bold;

--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--basic-text.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--basic-text.scss
@@ -2,5 +2,6 @@
   .field--name-field-plain-title {
     font-weight: $font-bold;
     font-size: 1.8rem;
+    margin-bottom: 1.7rem;
   }
 }

--- a/web/themes/custom/move_mil/scss/03-organisms/_uswds-middle-section.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_uswds-middle-section.scss
@@ -5,3 +5,9 @@
     padding-top: 1.5rem;
   }
 }
+
+.path-frontpage .usa-section.uswds-middle-section {
+  @include media($medium-screen) {
+    padding-top: 1.5rem;
+  }
+}

--- a/web/themes/custom/move_mil/scss/04-pages/_customer-service.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_customer-service.scss
@@ -2,6 +2,7 @@
   .paragraph--type--tabular-data-wrapper {
     position: relative;
     table-layout: fixed;
+    margin-top: 0;
 
     .paragraph--type--tabular-data {
       border-top: 1px solid $color-gray;

--- a/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
@@ -1,4 +1,6 @@
 .nightmare-moves {
+  position: relative;
+
   .field--name-field-paragraph {
     @include clearfix;
 

--- a/web/themes/custom/move_mil/scss/04-pages/_page--front.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_page--front.scss
@@ -5,6 +5,7 @@
   .region-sidebar-second {
     @include media($medium-screen) {
       float: right;
+      margin-top: 1rem;
     }
 
     &.usa-width-one-third {
@@ -111,6 +112,8 @@
 
   // our paragraphs in the main content section
   .field--name-field-paragraph {
+    padding-top: 0;
+
     > .field__item {
       border-bottom: 2px dotted $color-gray-cool-light;
 

--- a/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
@@ -5,4 +5,8 @@
     background-color: $color-gray-cool-light;
     margin-top: 0;
   }
+
+  .field--name-field-paragraph > .field__item:first-child .paragraph--text-with-image {
+    margin-top: 0;
+  }
 }

--- a/web/themes/custom/move_mil/scss/_variables.scss
+++ b/web/themes/custom/move_mil/scss/_variables.scss
@@ -10,13 +10,13 @@ $color-gray-cool-lightest: #f3f7fa;
 $sidenav-screen-width: 800px;
 $medium-large-screen: 951px !default;
 
-@mixin strip-paragraph-spacing() {
-  p {
+@mixin strip-paragraph-spacing($element: p) {
+  #{$element} {
     @include margin(0 null);
     line-height: normal;
+  }
 
-    + p {
-      margin-top: 1.6rem;
-    }
+  * + #{$element} {
+    margin-top: 1.6rem;
   }
 }


### PR DESCRIPTION
This pull request fully addresses Pivotal bug tickets [157849916 - standardize spacing below page title, broader scope than originally intended](https://www.pivotaltracker.com/story/show/157849916) and [157775887 - section dividers on Nightmare Moves page](https://www.pivotaltracker.com/story/show/157775887). It also *mostly* addresses [157847858 - spacing on some WYSIWYG two-column lists](https://www.pivotaltracker.com/story/show/157847858), and I recommended one or two slight content changes to wrap that one up.

The first story in particular will require ample testing and potentially some back-and-forth, so the sooner we can get it merged into the staging site, the better.

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Adds 20-25px of padding above the paragraphs wrapper field in ALL cases.
- Extends the spacing treatment of `p` elements within the intro text field to ALL wysiwyg fields, while softening it slightly to add padding above `p` elements when not the first child.
- Adds a few workarounds to address any unintended impacts of first two changes and get closer to uniform sitewide spacing standards.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Compile theme assets
1. Test all pages, at all screen widths.
1. Note and document any remaining discrepancies and suggested further changes to spacing below page title.

## Screenshots

_Attach relevant before and after screenshots here._