### PR TITLE
Feature/157485123/pro-tip-alignment

### DIFF
--- a/web/themes/custom/move_mil/scss/02-molecules/_pro-tip.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_pro-tip.scss
@@ -1,6 +1,7 @@
 p.pro-tip {
   padding: $spacing-small $spacing-small $spacing-small 50px;
   border: solid 1px $color-cool-blue-lightest;
+  position: relative;
 
   &:before {
     content: url('/themes/custom/move_mil/assets/img/icon--pro-tip.svg');


### PR DESCRIPTION
Very simple triage fixing Pivotal ticket [157485123 - WYSIWYG pro tip icon placement](https://www.pivotaltracker.com/story/show/157485123)

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- makes inline pro-tips position relative so the lightbulb doesn't fly off to strange places

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Compile theme assets
1. View pro-tips box in middle of Moving Guide page. The lightbulb icon should be where it usually is in a pro-tips box.

## Screenshots

### Broken on [staging](http://move-mil-stage.us-east-1.elasticbeanstalk.com/moving-guide#choose-how-to-ship-your-household-goods-move-types):
![moving with the military overview - staging - broken protip](https://user-images.githubusercontent.com/29130580/40550421-09cd47da-6008-11e8-94f5-eb1fda1bf9d2.png)


### Fixed locally:
![moving guide - local - protip fixed](https://user-images.githubusercontent.com/29130580/40550574-7f7e265c-6008-11e8-841c-bfe3f3158f73.png)