### PR TITLE
Back To Top button refactor and a couple other cleanup tweaks

### DIFF
--- a/web/themes/custom/move_mil/js/scrollFix.js
+++ b/web/themes/custom/move_mil/js/scrollFix.js
@@ -9,7 +9,7 @@
         // var targetId = href.substring(1, href.length);
         var target = $("div[id*='" + targetId + "']");
         var offset = $(target).offset();
-        offset.top -= 200;
+        offset.top -= 100;
         $('html, body').animate({
           scrollTop: offset.top,
           scrollLeft: 0
@@ -20,7 +20,22 @@
     });
   };
 
+  var smoothBackToTop = function(){
+    var topLink = $('.back-to-top a');
+    topLink.click(function(e) {
+      e.preventDefault();
+      $('html, body').animate({
+        scrollTop: 0,
+        scrollLeft: 0
+      }, 1000);
+      window.location.hash = '';
+      return;
+    });
+
+  };
+
   $(window).on('load', function() {
     offsetJumpScroll();
+    smoothBackToTop();
   });
 })(jQuery);

--- a/web/themes/custom/move_mil/js/stickyBackToTopButton.js
+++ b/web/themes/custom/move_mil/js/stickyBackToTopButton.js
@@ -1,0 +1,49 @@
+(function($) {
+  var checkPage = function() {
+    var button = $('.back-to-top');
+
+    if(button.length) {
+      var position = getPosition(button);
+      toggleSticky(button, position);
+      $(window).resize(function(){
+        position = getPosition(button);
+      });
+      $(window).on('scroll', function() {
+        toggleSticky(button, position);
+      });
+    }
+  };
+
+  var getPosition = function(stickyButton){
+    var pos;
+    if($('body').hasClass('user-logged-in') && $('body').hasClass('toolbar-fixed')) {
+      if($('body').hasClass('toolbar-horizontal') && $('body').hasClass('toolbar-tray-open')) {
+        pos = stickyButton.offset().top - 89;
+      }
+      else {
+        pos = stickyButton.offset().top - 49;
+      }
+    }
+    else {
+      pos = stickyButton.offset().top - 10;
+    }
+
+   return pos;
+  };
+
+  var toggleSticky = function(stickyButton, position) {
+    var scrollAmount = $(this).scrollTop();
+    var buttonLink = $(stickyButton).children('a');
+
+    if(scrollAmount > position && !stickyButton.hasClass('sticky')) {
+      stickyButton.addClass('sticky');
+    }
+    else if (scrollAmount < position && stickyButton.hasClass('sticky')){
+      stickyButton.removeClass('sticky');
+    }
+  };
+
+  $(window).on('load', function() {
+    checkPage();
+  });
+})(jQuery);

--- a/web/themes/custom/move_mil/scss/01-atoms/_back-to-top.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_back-to-top.scss
@@ -1,11 +1,11 @@
 .usa-section > .back-to-top {
   //positioning & alignment
   float: right;
-  position: -webkit-sticky;
-  position: sticky;
-  top: 1rem;
+  position: relative;
+  // position: -webkit-sticky;
+  // position: sticky;
   margin-top: 1rem;
-  z-index: 1000;
+  z-index: 499;
 
   @include media($nav-width) {
     margin-top: -2.7rem;
@@ -25,21 +25,32 @@
     font-size: $small-font-size;
     font-weight: $font-bold;
     text-decoration: none;
+    top: 1rem;
+    right: 0;
 
     &:hover,
     &:focus {
       text-decoration: underline;
     }
   }
+
+  // new sticky position workaround
+  &.sticky {
+    height: 3.3rem;
+
+    a {
+      position: fixed;
+    }
+  }
 }
 
 // account for admin toolbar
 .user-logged-in.toolbar-fixed {
-  .back-to-top {
+  .back-to-top a {
     top: 4.9rem;
   }
 
-  &.toolbar-horizontal.toolbar-tray-open .back-to-top {
+  &.toolbar-horizontal.toolbar-tray-open .back-to-top a {
     top: 8.9rem;
   }
 }

--- a/web/themes/custom/move_mil/scss/_variables.scss
+++ b/web/themes/custom/move_mil/scss/_variables.scss
@@ -14,6 +14,11 @@ $medium-large-screen: 951px !default;
   #{$element} {
     @include margin(0 null);
     line-height: normal;
+
+    + ul,
+    + ol {
+      margin-top: 1.6rem;
+    }
   }
 
   * + #{$element} {

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
@@ -28,9 +28,9 @@
               <a href="{{ titleLink }}">{{ content.field_image }}</a>
             {% elseif content.field_image|field_value == false and content.field_plain_title|field_value == true %}
               {% if titleLink is not empty %}
-                <h3 class="field-title-plain--link"><a href="{{ titleLink }}">{{ content.field_plain_title }}</a></h3>
+                <h3 class="field-title-plain--link"><a href="{{ titleLink }}">{{ content.field_plain_title.0 }}</a></h3>
               {% else %}
-                <h3 class="field-title-plain">{{ content.field_plain_title }}</h3>
+                <h3 class="field-title-plain">{{ content.field_plain_title.0 }}</h3>
               {% endif %}
             {% endif %}
 
@@ -39,9 +39,9 @@
 
             {% if content.field_image|field_value == true and content.field_plain_title|field_value == true %}
               {% if titleLink is not empty %}
-                <h3><a href="{{ titleLink }}">{{ content.field_plain_title }}</a></h3>
+                <h3><a href="{{ titleLink }}">{{ content.field_plain_title.0 }}</a></h3>
               {% else %}
-                <h3>{{ content.field_plain_title }}</h3>
+                <h3>{{ content.field_plain_title.0 }}</h3>
               {% endif %}
             {% endif %}
             {{ content.field_body }}


### PR DESCRIPTION
Main purpose of this PR is to address Pivotal bug tickets [157850939 - Back To Top button not scrolling in IE](https://www.pivotaltracker.com/story/show/157850939) and [157847898 - Back To Top button appearing over mobile menu](https://www.pivotaltracker.com/story/show/157847898). It also adds smooth scrolling to the Back to Top button (not covered in Pivotal) and follows through with additional cleanup associated with [image positioning on certain paragraphs](https://www.pivotaltracker.com/story/show/157485059) and [general spacing issues at or near the top of the main content area](https://www.pivotaltracker.com/story/show/157849916).

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Uses jQuery, including two constantly-running window listeners, and css `position: fixed` to functionally recreate the `position: sticky` css property that works in most browsers but not IE. I already did some cross-browser checking including our P1-P4 browsers, and the "Back to Top" button works largely the same and now works in IE, but further, more comprehensive testing once deployed will be necessary. Some mobile browsers, especially older versions, might be more sluggish and/or jumpy than they had been with `position: sticky`.
- Decreases the z-index of the "Back to Top" button from 9999 to 499, just less than the mobile menu's z-index of 500.
- Adds smooth scrolling to the "Back to Top" button, similar to the treatment I'd added to jump links early on.
- Tweaks the scroll amount when clicking on a jump link so the top of the targeted section appears 100px down the page (was 200px, which looked weird on mobile landscape and some smaller desktop/laptop browsers)
- Cleans up an unintended impact of a previous spacing change by adding margin between adjacent `<p>` and `<ul> or <ol>` tags
- Makes a modest change to the Text with Image paragraph Twig template to move the external link signifier icon in line with some title field links on the Helpful Links page. They had been breaking to the next line.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Compile theme assets
1. Lots of testing, but mostly on Feld's plate

## Screenshots

### Fixed

***Note: screenshots insufficient to capture main button positioning story***

No Back to Top button over mobile menu - (local, all browsers):
![screen shot 2018-05-30 at 8 19 52 pm](https://user-images.githubusercontent.com/29130580/40754339-dcf39410-6446-11e8-85ab-28cdc917764b.png)

External links inline (local, all browsers):
![screen shot 2018-05-30 at 8 22 16 pm](https://user-images.githubusercontent.com/29130580/40754410-3934add6-6447-11e8-8afd-2370133ae789.png)
