### PR TITLE
Simple text edit in menu module

### DIFF
--- a/web/modules/custom/custom_move_mil_menus/custom_move_mil_menus.links.menu.yml
+++ b/web/modules/custom/custom_move_mil_menus/custom_move_mil_menus.links.menu.yml
@@ -30,7 +30,7 @@ main_menu.moving_guide:
   weight: 1
 
 main_menu.tutorials:
-  title: 'Tutorial'
+  title: 'Tutorials'
   url: 'internal:/tutorials'
   menu_name: main_menu
   weight: 2


### PR DESCRIPTION
This PR executes Pivotal ticket [157847990 - "Tutorial" main navigation item needs to be pluralised](https://www.pivotaltracker.com/story/show/157847990). It simply adds an "s" onto the "Tutorial" item's text in the menu links yml file to make it "Tutorials".

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- See above

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Update the `custom_move_mil_menus` module if needed
1. See the update in the main nav menu

## Screenshots

### [Staging](http://move-mil-stage.us-east-1.elasticbeanstalk.com/) - with bug
![screen shot 2018-05-31 at 7 47 55 pm](https://user-images.githubusercontent.com/29130580/40813962-898608f6-650b-11e8-896e-6d4b5b02547e.png)


### Local - fixed
![screen shot 2018-05-31 at 7 46 36 pm](https://user-images.githubusercontent.com/29130580/40813937-62f8d466-650b-11e8-837c-7defe2ba88f2.png)
