### PR TITLE
Feature/157852014/clean breadcrumb parents

### DIFF
--- a/config/sync/block.block.servicespecific.yml
+++ b/config/sync/block.block.servicespecific.yml
@@ -24,6 +24,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/service-specific-information/\r\n/service-specific-information/*"
+    pages: "/service-specific-information\r\n/service-specific-information/*"
     negate: false
     context_mapping: {  }

--- a/web/themes/custom/move_mil/templates/system/block/breadcrumb.html.twig
+++ b/web/themes/custom/move_mil/templates/system/block/breadcrumb.html.twig
@@ -10,7 +10,15 @@
 {% for item in breadcrumb %}
   <li class="usa-nav-secondary-links">
     {% if item.url %}
-      <a href="{{ item.url }}">{{ item.text }}</a>
+      {% if item.url == "/moving-guide" %}
+        <a href="{{ item.url }}">Moving Guide</a>
+      {% elseif item.url == "/service-specific-information" %}
+        <a href="{{ item.url }}">Service-Specific Information</a>
+      {% elseif item.url == "/tutorials" %}
+        <a href="{{ item.url }}">Tutorials</a>
+      {% else %}
+        <a href="{{ item.url }}">{{ item.text }}</a>
+      {% endif %}
     {% else %}
       {{ item.text }}
     {% endif %}


### PR DESCRIPTION
This pull request executes Pivotal ticket [157852014 - some wrong page names in breadcrumbs](https://www.pivotaltracker.com/story/show/157852014). This bug ticket was originally designed specifically to address the Service-Specific Information pages, where "Army" was appearing as the parent item instead of "Service-Specific Information". However, the same problem also occurs under the Moving Guide and Tutorials sections, so it was very little added LOE to address all of them in one set of changes.

I also noticed that the Army page had lost its jump links sidebar and quickly figured out that it was likely an unintended bug, so I added a config tweak to address that.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Hardcodes workarounds for the three instances of misnamed link text in the breadcrumbs Twig template.
- Changes one of the paths including the Service-Specific Information links menu from `/service-specific-information/` to `/service-specific-information`. That trailing slash was keeping the block from appearing on the parent (really the Army) page.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Import config
1. Check various pages under the Moving Guide, Service-Specific Information and Tutorials sections to ensure the breadcrumb paths look as intended.
1. Go to /service-specific-information, assuming it is still the Army and make sure the sidebar links are there.

## Screenshots

### Nightmare Moves page:
Staging - before:
![screen shot 2018-05-31 at 8 03 50 pm](https://user-images.githubusercontent.com/29130580/40814360-c9e1ee5e-650d-11e8-82a3-7d9f48f47ec1.png)

Local - fixed:
![screen shot 2018-05-31 at 8 02 35 pm](https://user-images.githubusercontent.com/29130580/40814335-a6acd214-650d-11e8-9b37-4a184d2a7036.png)

### Navy page:
Staging - before:
![screen shot 2018-05-31 at 8 05 36 pm](https://user-images.githubusercontent.com/29130580/40814399-02f163fa-650e-11e8-9c85-40ee8f0df948.png)

Local - fixed:
![screen shot 2018-05-31 at 8 05 01 pm](https://user-images.githubusercontent.com/29130580/40814385-f065c280-650d-11e8-8d30-2816df3d9319.png)

### Create a Shipment Tutorial
Staging - before:
![screen shot 2018-05-31 at 8 06 27 pm](https://user-images.githubusercontent.com/29130580/40814423-2204b454-650e-11e8-8486-3656be4bb0b4.png)

Local - fixed:
![screen shot 2018-05-31 at 8 07 16 pm](https://user-images.githubusercontent.com/29130580/40814434-3e5d7cc6-650e-11e8-8e6e-b5f8500e42ae.png)