### PR TITLE
Feature 158078151 new website field on customer service pgraph type

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.customer_service_box.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.customer_service_box.default.yml
@@ -12,9 +12,11 @@ dependencies:
     - field.field.paragraph.customer_service_box.field_plain_title
     - field.field.paragraph.customer_service_box.field_service_address
     - field.field.paragraph.customer_service_box.field_service_description
+    - field.field.paragraph.customer_service_box.field_website
     - paragraphs.paragraphs_type.customer_service_box
   module:
     - address
+    - link
     - telephone
     - text
 id: paragraph.customer_service_box.default
@@ -23,28 +25,28 @@ bundle: customer_service_box
 mode: default
 content:
   field_comm_fax:
-    weight: 7
+    weight: 8
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: telephone_default
     region: content
   field_comm_phone:
-    weight: 6
+    weight: 7
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: telephone_default
     region: content
   field_dsn_fax:
-    weight: 5
+    weight: 6
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: telephone_default
     region: content
   field_dsn_phone:
-    weight: 4
+    weight: 5
     settings:
       placeholder: ''
     third_party_settings: {  }
@@ -59,7 +61,7 @@ content:
     type: email_default
     region: content
   field_other_details:
-    weight: 8
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
@@ -88,6 +90,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_website:
+    weight: 4
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
     region: content
 hidden:
   created: true

--- a/config/sync/core.entity_view_display.paragraph.customer_service_box.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.customer_service_box.default.yml
@@ -12,9 +12,11 @@ dependencies:
     - field.field.paragraph.customer_service_box.field_plain_title
     - field.field.paragraph.customer_service_box.field_service_address
     - field.field.paragraph.customer_service_box.field_service_description
+    - field.field.paragraph.customer_service_box.field_website
     - paragraphs.paragraphs_type.customer_service_box
   module:
     - address
+    - link
     - telephone
     - text
 id: paragraph.customer_service_box.default
@@ -23,7 +25,7 @@ bundle: customer_service_box
 mode: default
 content:
   field_comm_fax:
-    weight: 7
+    weight: 8
     label: inline
     settings:
       title: ''
@@ -31,7 +33,7 @@ content:
     type: telephone_link
     region: content
   field_comm_phone:
-    weight: 6
+    weight: 7
     label: inline
     settings:
       title: ''
@@ -39,7 +41,7 @@ content:
     type: telephone_link
     region: content
   field_dsn_fax:
-    weight: 5
+    weight: 6
     label: inline
     settings:
       title: ''
@@ -47,7 +49,7 @@ content:
     type: telephone_link
     region: content
   field_dsn_phone:
-    weight: 4
+    weight: 5
     label: inline
     settings:
       title: ''
@@ -62,7 +64,7 @@ content:
     type: basic_string
     region: content
   field_other_details:
-    weight: 8
+    weight: 9
     label: hidden
     settings: {  }
     third_party_settings: {  }
@@ -88,5 +90,17 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_website:
+    weight: 4
+    label: hidden
+    settings:
+      trim_length: 250
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    type: link
     region: content
 hidden: {  }

--- a/config/sync/field.field.paragraph.customer_service_box.field_website.yml
+++ b/config/sync/field.field.paragraph.customer_service_box.field_website.yml
@@ -1,0 +1,23 @@
+uuid: e4ccf1c4-065f-4f4e-8f01-6128b069be42
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_website
+    - paragraphs.paragraphs_type.customer_service_box
+  module:
+    - link
+id: paragraph.customer_service_box.field_website
+field_name: field_website
+entity_type: paragraph
+bundle: customer_service_box
+label: Website
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/sync/field.storage.paragraph.field_website.yml
+++ b/config/sync/field.storage.paragraph.field_website.yml
@@ -1,0 +1,19 @@
+uuid: 2953c98b-5bac-43ea-bb7c-f31c19d4f12a
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_website
+field_name: field_website
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--customer-service-box.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--customer-service-box.html.twig
@@ -32,6 +32,15 @@
             {% endfor %}
           {% endif %}
 
+          {% if content.field_website|field_value == true %}
+            {% for key, item in content.field_website if key matches '/^\\d+$/' %}
+              <tr class="svc-spec-links--group">
+                <th class="svc-spec-links--title">{{ content.field_website['#title'] }}</th>
+                <td class="svc-spec-links--content"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
+              </tr>
+            {% endfor %}
+          {% endif %}
+
           {% if content.field_dsn_phone|field_value == true %}
             {% for key, item in content.field_dsn_phone if key matches '/^\\d+$/' %}
               <tr class="svc-spec-links--group">


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- includes new field and template update to allow for a website url link

## Testing

To verify the changes proposed in this pull request…

1. pull changes locally
2. make cim
3. make cr
4. navigate to the /admin/structure/paragraphs_type/customer_service_box/fields and you will find a new field at the bottom of the field listing for Website link

## Screenshots
<img width="931" alt="screen shot 2018-06-04 at 1 43 44 pm" src="https://user-images.githubusercontent.com/37077057/40932800-84b12f28-67fd-11e8-9eb7-55c1e60e1167.png">
<img width="892" alt="screen shot 2018-06-04 at 1 43 25 pm" src="https://user-images.githubusercontent.com/37077057/40932804-879ab8b2-67fd-11e8-90de-ef4ad9af50a2.png">
<img width="227" alt="screen shot 2018-06-04 at 1 42 57 pm" src="https://user-images.githubusercontent.com/37077057/40932810-8a90c066-67fd-11e8-8f1c-c3b7b3c7529c.png">

