### PR TITLE
new styles at mobile breakpoint to prevent overflow at mobile

### DIFF
--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--tabular-data-wrapper.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--tabular-data-wrapper.scss
@@ -1,10 +1,15 @@
 .paragraph--type--tabular-data-wrapper {
-  display: table;
   border-collapse: collapse;
   margin: 3rem 0;
 
+  @include media($medium-screen) {
+    display: table;
+  }
+
   .paragraph--type--tabular-data {
-    display: table-row;
+    @include media($medium-screen) {
+      display: table-row;
+    }
 
     > div {
       display: block;
@@ -15,6 +20,19 @@
       &.tabular-data-left {
         align-items: center;
         display: flex;
+        width: 100%;
+
+        @include media($medium-screen) {
+          width: auto;
+        }
+
+        .field-image-title-subtitle {
+          max-width: calc(100% / 3 * 2);
+
+          @include media($medium-screen) {
+            max-width: 100%;
+          }
+        }
       }
     }
 
@@ -25,6 +43,11 @@
     img {
       margin-right: $site-margins-mobile;
       vertical-align: middle;
+      max-width: calc(100% / 3 * 1);
+
+      @include media($medium-screen) {
+        max-width: 100%;
+      }
 
       + abbr {
         vertical-align: middle;
@@ -33,8 +56,11 @@
 
     @include media($medium-screen) {
       > div.tabular-data-left, div.tabular-data-right {
-        display: table-cell;
         border-top: 1px solid $color-gray;
+
+        @include media($medium-screen) {
+          display: table-cell;
+        }
 
         &.tabular-data-left {
           vertical-align: top;


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- updates the styles of tabular data paragraph types to prevent overflow of content at mobile

## Testing

To verify the changes proposed in this pull request…

1. pull changes locally
2. at the theme root, npm run build
3. navigate to /entitlements
4. check across browsers, including ie that all tabular cells are now responsive with proper margins

## Screenshots

**updated view on ie11 win10**
<img width="1267" alt="screen shot 2018-06-05 at 12 50 51 pm" src="https://user-images.githubusercontent.com/37077057/40990714-b70b9f04-68bf-11e8-80b2-b3a2c6e7c0b3.png">
<img width="395" alt="screen shot 2018-06-05 at 12 51 21 pm" src="https://user-images.githubusercontent.com/37077057/40990720-bb204f86-68bf-11e8-9f16-f6e28add1b06.png">
