### PR TITLE
CONFIG | removing our floated field values

### DIFF
--- a/config/sync/field.storage.paragraph.field_protip_alignment.yml
+++ b/config/sync/field.storage.paragraph.field_protip_alignment.yml
@@ -12,12 +12,6 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: 'float left'
-      label: left
-    -
-      value: 'float right'
-      label: right
-    -
       value: 'span top (100%)'
       label: top
     -


### PR DESCRIPTION
I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- removes the float values so users will no longer be able to select L | R for pro-tip paragraph alignment, only Top | Bottom

## Testing

To verify the changes proposed in this pull request…

1. pull changes locally
2. navigate to Home >Administration >Structure >Paragraphs types >Pro tip >Manage fields > Protip_alignment
3. you should no longer see the following values

**float left | left
float left | right**

## Screenshots

<img width="1320" alt="screen shot 2018-06-06 at 5 31 13 pm" src="https://user-images.githubusercontent.com/37077057/41066439-cc9d4c5a-69af-11e8-9d39-f80fb88e8eaf.png">
