### PR TITLE
Feature/157849818/text with image paragraph dividers

### DIFF
--- a/web/themes/custom/move_mil/scss/01-atoms/_content-columns.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_content-columns.scss
@@ -5,7 +5,6 @@
   &.usa-grid-full {
     > :first-child {
       margin-top: 1em;
-      margin-bottom: 1em;
     }
 
     .content-column {
@@ -13,7 +12,6 @@
       &.usa-width-one-third,
       &.usa-width-one-fourth {
         margin-top: 1em;
-        margin-bottom: 1em;
       }
 
       ul, ol {

--- a/web/themes/custom/move_mil/scss/01-atoms/_facebook-link.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_facebook-link.scss
@@ -1,7 +1,7 @@
 a.facebook-link {
   display: block;
   text-decoration: none;
-  padding-top: .5rem;
+  padding-top: 0.5rem;
 
   // &:hover, &:focus {
   //   text-decoration: underline;
@@ -13,6 +13,6 @@ a.facebook-link {
 
   img {
     height: 1.9rem;
-    padding-left: .5rem;
+    padding-left: 0.5rem;
   }
 }

--- a/web/themes/custom/move_mil/scss/01-atoms/_jump-link-section-divider.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_jump-link-section-divider.scss
@@ -10,3 +10,21 @@
     }
   }
 }
+
+// one-off cases targeted by page
+.retirees-separatees,
+.tools-resources {
+  .field--name-field-paragraph {
+    .field__item:not(:first-child) {
+      > .paragraph--text-with-image {
+        padding-top: 3rem;
+        margin-top: 0;
+        border-top: 1px solid $color-cool-blue-lightest;
+
+        > .paragraph--text-with-image {
+          margin: 0;
+        }
+      }
+    }
+  }
+}

--- a/web/themes/custom/move_mil/scss/01-atoms/_text-formatted.scss
+++ b/web/themes/custom/move_mil/scss/01-atoms/_text-formatted.scss
@@ -1,4 +1,12 @@
 // WYSIWYG fields
 .field.text-formatted {
   @include strip-paragraph-spacing();
+  @include strip-paragraph-spacing(ul);
+  @include strip-paragraph-spacing(ol);
+
+  ul, ol {
+    ul, ol {
+      @include margin(1em null);
+    }
+  }
 }

--- a/web/themes/custom/move_mil/scss/02-molecules/_field--name-field-page-intro-text.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_field--name-field-page-intro-text.scss
@@ -5,7 +5,6 @@
 
   @include margin(2rem 0-$site-margins-mobile);
   @include padding($site-margins-mobile);
-  @include strip-paragraph-spacing();
 
   @include media($medium-screen) {
     @include margin(2rem 0);

--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--text-with-image.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--text-with-image.scss
@@ -18,7 +18,6 @@
     }
 
     .usa-media_block-img { // this is a class associated with an image or a title that gets aligned
-      margin: 0 0 $spacing-medium 0;
 
       &__align-right {
         order: 1;
@@ -54,7 +53,6 @@
     }
 
     .usa-media_block-body {
-      margin: 0 0 $spacing-medium 0;
 
       &.usa-width-two-thirds {
         max-width: 50rem;

--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--tutorial-slideshow.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--tutorial-slideshow.scss
@@ -11,6 +11,10 @@
       font-family: $font-sans;
       text-transform: uppercase;
     }
+
+    + .field--name-field-pro-tip {
+      margin-top: $spacing-medium;
+    }
   }
 
   .field--name-field-slideshow-description {

--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--tabular-data-wrapper.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--tabular-data-wrapper.scss
@@ -68,6 +68,12 @@
         margin-bottom: $site-margins-mobile;
         padding-bottom: $site-margins-mobile;
       }
+
+      .field--name-field-body {
+        > ul:last-child {
+          margin-bottom: 1em;
+        }
+      }
     }
   }
 }

--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--warning-callout-box.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--type--warning-callout-box.scss
@@ -1,9 +1,7 @@
 .paragraph--type--warning-callout-box {
+  margin-bottom: $spacing-medium;
+
   .field--name-field-plain-title {
     @include h3();
-  }
-
-  .field--name-field-body {
-    @include strip-paragraph-spacing();
   }
 }

--- a/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
@@ -2,10 +2,8 @@
   .field--name-field-paragraph {
     @include clearfix;
 
-    .paragraph--pro-tip .usa-width-one-third {
-      float: none;
-      margin: 0;
-      width: 100%;
+    .paragraph--pro-tip {
+      margin: $spacing-medium 0;
     }
 
     @include media($medium-large-screen) {
@@ -23,6 +21,9 @@
         &:nth-child(2n) {
           float: right;
           width: 35%;
+          .paragraph--pro-tip {
+            margin: 0;
+          }
         }
 
         &:nth-child(n+3) {

--- a/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
@@ -21,6 +21,7 @@
         &:nth-child(2n) {
           float: right;
           width: 35%;
+
           .paragraph--pro-tip {
             margin: 0;
           }

--- a/web/themes/custom/move_mil/scss/04-pages/_page--front.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_page--front.scss
@@ -130,10 +130,11 @@
     .paragraph--text-with-image__align-left {
       flex-direction: row;
 
-      .field--name-field-plain-title {
+      h3 {
         color: #205493;
         font-size: 2.5rem;
         font-weight: $font-normal;
+        margin: 0 0 $spacing-medium;
 
         @include media($medium-screen) {
           font-size: 3.5rem;
@@ -154,11 +155,11 @@
           min-width: 0;
           width: 4rem;
           position: relative;
-          top: 2rem;
+          // top: 2rem;
 
           @include media($medium-screen) {
             width: 100%;
-            top: 0;
+            // top: 0;
           }
         }
       }
@@ -173,7 +174,7 @@
         }
 
         > h3 {
-          margin-left: 4.5rem;
+          margin-left: 5rem;
 
           @include media($medium-screen) {
             margin-left: 0;

--- a/web/themes/custom/move_mil/scss/04-pages/_retirees-separatees.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_retirees-separatees.scss
@@ -1,0 +1,7 @@
+.retirees-separatees {
+
+  // one-off to remove divider above top text with image paragraph just below a section title
+  .field--name-field-paragraph .field__item:nth-child(2) > .paragraph--text-with-image {
+    border-top: 0;
+  }
+}

--- a/web/themes/custom/move_mil/scss/04-pages/_retirees-separatees.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_retirees-separatees.scss
@@ -1,7 +1,15 @@
 .retirees-separatees {
 
   // one-off to remove divider above top text with image paragraph just below a section title
-  .field--name-field-paragraph .field__item:nth-child(2) > .paragraph--text-with-image {
-    border-top: 0;
+  .field--name-field-paragraph {
+    .field__item:first-child {
+      h3 {
+        margin: 0;
+      }
+    }
+
+    .field__item:nth-child(2) > .paragraph--text-with-image {
+      border-top: 0;
+    }
   }
 }

--- a/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
@@ -6,18 +6,22 @@
     margin-top: 0;
   }
 
-  .field--name-field-paragraph > .field__item:first-child .paragraph--text-with-image {
-    margin-top: 0;
-  }
+  .field--name-field-paragraph {
+    > .field__item {
+      .paragraph--text-with-image {
+        .usa-media_block-body {
+          > h3 {
+            margin-top: 2rem;
 
-  .paragraph--text-with-image {
-    .usa-media_block-body {
-      > h3 {
-        margin-top: 2rem;
-
-        @include media($medium-screen) {
-          margin-top: 0;
+            @include media($medium-screen) {
+              margin-top: 0;
+            }
+          }
         }
+      }
+
+      &:first-child .paragraph--text-with-image {
+        margin-top: 0;
       }
     }
   }

--- a/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_tools-resources.scss
@@ -9,4 +9,16 @@
   .field--name-field-paragraph > .field__item:first-child .paragraph--text-with-image {
     margin-top: 0;
   }
+
+  .paragraph--text-with-image {
+    .usa-media_block-body {
+      > h3 {
+        margin-top: 2rem;
+
+        @include media($medium-screen) {
+          margin-top: 0;
+        }
+      }
+    }
+  }
 }

--- a/web/themes/custom/move_mil/scss/_variables.scss
+++ b/web/themes/custom/move_mil/scss/_variables.scss
@@ -14,14 +14,9 @@ $medium-large-screen: 951px !default;
   #{$element} {
     @include margin(0 null);
     line-height: normal;
-
-    + ul,
-    + ol {
-      margin-top: 1.6rem;
-    }
   }
 
   * + #{$element} {
-    margin-top: 1.6rem;
+    margin-top: 1em;
   }
 }


### PR DESCRIPTION
This PR addresses a number of Pivotal tickets, primarily [157849818 - section dividers on some instances of text with image paragraphs](https://www.pivotaltracker.com/story/show/157849818) and [158150749 - spacing between warning/callout boxes](https://www.pivotaltracker.com/story/show/158150749). It also performs general cleanup and refinement related to spacing that touches upon a large number of tickets in both current and previous sprints.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Adds section dividers between Text with Image paragraphs on Retirees/Separatees and Helpful Links pages.
- Strips margin above first Text with Image paragraph on Helpful Links page
- Strips spacing above/below orphan h3 on top of Retirees/Separatees page that was there before but less noticeable (unrelated to section dividers).
- Changes treatment of `ul` and `ol` elements within WYSIWYG fields to mimic that already established for `p` elements. Adds spacing back in around second-level lists and in specific cases where warranted (eg bottom of tabular data paragraphs). Globalizes that treatment of `p` elements and removes duplicative code.
- Removes margin below text-with-image paragraph sections that were causing excessing spacing on mobile
- Adds top margin to the pro-tip field in Tutorial slides and top and bottom margin to the pro-tip paragraph on the Nightmare Moves page.
- Adds 20px spacing below all Warning/Callout boxes. Only affects Service-Specific pages at the moment but better done as global change.
- Fixes a bug that I'd inadvertently introduced earlier in the sprint as part of [157849916 - more general spacing cleanup](https://www.pivotaltracker.com/story/show/157849916), adding styling back into the section titles of the Text with Image paragraphs on the home page.
- Related to the aforementioned item on home page section titles, tweaks some spacing in that section to better match the current live site.
- Cleans up some residual linter errors (final commit)

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Compile theme assets
1. QA like the wind!

## Screenshots

Far too many screenshots needed to justify placing here, as these fixes are relevant to nearly every page and section of the site. Recommend thorough local QA instead if deemed worthwhile.