### PR TITLE
TRIAGE: put position relative back on nightmare moves article wrapper

### DIFF
--- a/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_nightmare-moves.scss
@@ -1,4 +1,6 @@
 .nightmare-moves {
+  position: relative;
+
   .field--name-field-paragraph {
     @include clearfix;
 


### PR DESCRIPTION
Re-does [very simple previous commit](https://github.com/Bixal/move.mil/pull/150/commits/c9fe705630ebcd5c53ed35ec1c11b329ebe5df45) from last sprint that was inadvertently wiped away last week.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Adds position: relative back into nightmare moves page so dividers don't go full width

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. compile theme assets
1. Go to nightmare moves page (NOT LOGGED IN) and make sure section dividers do not extend beyond the main text area.

## Screenshots

Fixed on local:
<img width="1096" alt="screen shot 2018-06-07 at 12 03 57 pm" src="https://user-images.githubusercontent.com/29130580/41111742-ec036ac0-6a4a-11e8-8d9c-1f3755297eda.png">
