### PR TITLE
Feature 157776405 wordbreak links cross browsers

### DIFF
--- a/web/themes/custom/move_mil/scss/02-molecules/_paragraph--customer-service-box.scss
+++ b/web/themes/custom/move_mil/scss/02-molecules/_paragraph--customer-service-box.scss
@@ -10,11 +10,6 @@
     margin: 0;
   }
 
-  a {
-    word-break: break-all;
-    display: inline-block;
-  }
-
   h3.svc-title {
     font-size: 1.4rem;
   }
@@ -49,6 +44,20 @@
           padding: 0;
           border: 0;
           background-color: transparent;
+
+          &-adddress,
+          &-comm-fax,
+          &-comm-phone,
+          &-dsn-fax,
+          &-dsn-phone,
+          &-website,
+          &-email {
+
+            a {
+              word-break: break-all;
+              display: inline-block;
+            }
+          }
         }
       }
     }

--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--customer-service-box.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--customer-service-box.html.twig
@@ -27,7 +27,7 @@
             {% for key, item in content.field_email if key matches '/^\\d+$/' %}
               <tr class="svc-spec-links--group">
                 <th class="svc-spec-links--title">{{ content.field_email['#title'] }}</th>
-                <td class="svc-spec-links--content"><a mailto="{{ item['#context'].value }}">{{ item['#context'].value }}</a></td>
+                <td class="svc-spec-links--content svc-spec-links--content-email"><a mailto="{{ item['#context'].value }}">{{ item['#context'].value }}</a></td>
               </tr>
             {% endfor %}
           {% endif %}
@@ -36,7 +36,7 @@
             {% for key, item in content.field_website if key matches '/^\\d+$/' %}
               <tr class="svc-spec-links--group">
                 <th class="svc-spec-links--title">{{ content.field_website['#title'] }}</th>
-                <td class="svc-spec-links--content"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
+                <td class="svc-spec-links--content svc-spec-links--content-website"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
               </tr>
             {% endfor %}
           {% endif %}
@@ -45,7 +45,7 @@
             {% for key, item in content.field_dsn_phone if key matches '/^\\d+$/' %}
               <tr class="svc-spec-links--group">
                 <th class="svc-spec-links--title">{{ content.field_dsn_phone['#title'] }}</th>
-                <td class="svc-spec-links--content"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
+                <td class="svc-spec-links--content svc-spec-links--content-dsn-phone"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
               </tr>
             {% endfor %}
           {% endif %}
@@ -54,7 +54,7 @@
             {% for key, item in content.field_dsn_fax if key matches '/^\\d+$/' %}
               <tr class="svc-spec-links--group">
                 <th class="svc-spec-links--title">{{ content.field_dsn_fax['#title'] }}</th>
-                <td class="svc-spec-links--content"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
+                <td class="svc-spec-links--content svc-spec-links--content-dsn-fax"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
               </tr>
             {% endfor %}
           {% endif %}
@@ -63,7 +63,7 @@
             {% for key, item in content.field_comm_phone if key matches '/^\\d+$/' %}
               <tr class="svc-spec-links--group">
                 <th class="svc-spec-links--title">{{ content.field_comm_phone['#title'] }}</th>
-                <td class="svc-spec-links--content"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
+                <td class="svc-spec-links--content svc-spec-links--content-comm-phone"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
               </tr>
             {% endfor %}
           {% endif %}
@@ -72,7 +72,7 @@
             {% for key, item in content.field_comm_fax if key matches '/^\\d+$/' %}
               <tr class="svc-spec-links--group">
                 <th class="svc-spec-links--title">{{ content.field_comm_fax['#title'] }}</th>
-                <td class="svc-spec-links--content"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
+                <td class="svc-spec-links--content svc-spec-links--content-comm-fax"><a href="{{ item['#url'].uri }}">{{ item['#title'] }}</a></td>
               </tr>
             {% endfor %}
           {% endif %}
@@ -81,7 +81,7 @@
         {% if content.field_service_address|field_value == true %}
             <div class="svc-spec-links--address-group">
               <dt class="svc-spec-links--title">{{ content.field_service_address['#title'] }}</dt>
-              <dd class="svc-spec-links--content">
+              <dd class="svc-spec-links--content svc-spec-links--content-adddress">
                 <address>{{ content.field_service_address[0] }}</address>
               </dd>
             </div>


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- updates break-word/overflow-wrap on the parent callout box to handle the non-breaking links (the big one at the bottom of Marine Corps for example, and then anything else (email/etc) with the more specific break-all on the fields as needed
- adds new classes to our template

## Testing

To verify the changes proposed in this pull request…

1. pull changes locally
2. cd to theme root, npm run build
3. navigate to /service-specific-information/marine-corps
4. in IE you will see that the fields with the following class extensions break-all, while other links on break-word

**noted here with phone numbers vs. marine corps links**

<img width="870" alt="screen shot 2018-06-07 at 1 02 22 pm" src="https://user-images.githubusercontent.com/37077057/41115376-4b50b3ac-6a55-11e8-8cfa-242da6fade6d.png">
