### PR TITLE
Internet Explorer is a flaming dumpster fire of a browser

### DIFF
--- a/web/themes/custom/move_mil/scss/03-organisms/_usa-footer-secondary_section.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_usa-footer-secondary_section.scss
@@ -6,6 +6,10 @@
 
   .usa-footer-logo-img {
     float: none;
+
+    &.usa-footer-big-logo-img {
+      height: 10rem;
+    }
   }
 
   .footer-agency--content {

--- a/web/themes/custom/move_mil/scss/03-organisms/_usa-header-extended.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_usa-header-extended.scss
@@ -46,6 +46,11 @@
         width: 18.5rem;
         z-index: 501;
       }
+
+      // harcoding logo size for IE because IE is stupid
+      img {
+        height: 18.5rem;
+      }
     }
 
     .usa-logo-text-area {

--- a/web/themes/custom/move_mil/scss/04-pages/_page--front.scss
+++ b/web/themes/custom/move_mil/scss/04-pages/_page--front.scss
@@ -60,6 +60,7 @@
         margin: 0 auto $spacing-md-small auto;
 
         img {
+          height: 120px;
           margin: 0 auto $spacing-md-small auto;
         }
 


### PR DESCRIPTION
This PR set static heights on logos in header, footer and home page service-specific section because Internet Explorer's continued existence at this point is almost entirely dependent on Microsoft's marketing to stolid, risk-averse institutions that are afraid of adaptation to accommodate the proliferation of things that work.

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Sets fixed heights on three instances where logos are stretching to their original heights despite conforming to set widths on IE11 in older versions of Windows.
- Specifically, fixes this issue in the Transcom logos in the header and footer on all pages, and the five service-specific icons at the bottom of the home page. 

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Compile theme assets
1. Using Browserstack or another emulator, visit the home page in IE11 on Window 7 and/or 8.1 to verify image integrity.

## Screenshots
*Note: all on Windows 7 and IE11, accessed through Browserstack*

### Header Transcom logo:

Staging - broken:
<img width="335" alt="win7ie11 - header logo - staging broken" src="https://user-images.githubusercontent.com/29130580/41482490-c8250af0-70a3-11e8-8e94-44cfb4024696.png">

Local - fixed:
<img width="541" alt="win7ie11 - header logo - local fixed" src="https://user-images.githubusercontent.com/29130580/41482395-7fb75624-70a3-11e8-8513-51ca5316f28f.png">


### Service-specific icons and footer Transcom logo:

Staging - broken:
<img width="1047" alt="win7ie11 - service-specific icons - staging broken" src="https://user-images.githubusercontent.com/29130580/41482552-ee935e62-70a3-11e8-8eb1-d34c7732638a.png">
<img width="645" alt="win7ie11 - footer logo - staging broken" src="https://user-images.githubusercontent.com/29130580/41482584-07202d16-70a4-11e8-9116-b909000136b5.png">


Local - fixed:
<img width="1047" alt="win7ie11 - bottom icons - local fixed" src="https://user-images.githubusercontent.com/29130580/41478790-fb5e71fc-7096-11e8-93b9-affa00413add.png">
