### PR TITLE
Updates to vis-testing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ prune:
 	@docker-compose down -v
 
 ps:
-	@docker ps --filter name='$(PROJECT_NAME)*'
+	@docker ps --filter name="$(PROJECT_NAME)*"
 
 shell:
-	docker exec -ti $(shell docker ps --filter name='$(PROJECT_NAME)_php' --format "{{ .ID }}") sh
+	docker exec -ti "$(shell docker ps --filter name="$(PROJECT_NAME)_php" --format "{{ .ID }}") sh"
 
 dbdump:
 	@echo "Creating Database Dump for $(PROJECT_NAME)..."
@@ -35,7 +35,7 @@ dbrestore:
 
 uli:
 	@echo "Getting admin login"
-	docker-compose run php drush user:login --uri='$(PROJECT_BASE_URL)':8000
+	docker-compose run php drush user:login --uri="$(PROJECT_BASE_URL)":8000
 
 cim:
 	@echo "Importing Configuration"
@@ -77,3 +77,33 @@ parser:
 dbclient:
 	@echo "Opening Move.mil DB client"
 	docker-compose run php drupal database:client
+
+build-tools:
+	@echo "Building our custom tools..."
+	
+	@echo "Building our weight estimator..."
+	@if [ ! -d "./web/modules/custom/react_tools/tools/react-weight-estimator/src/localcss/" ]; then echo "Creating Directory..." && cd ./web/modules/custom/react_tools/tools/react-weight-estimator/src/ && mkdir localcss; fi
+	@cd ./web/modules/custom/react_tools/tools/react-weight-estimator/src/sass/; sass main.scss ../localcss/main.css
+	@cd ./web/modules/custom/react_tools/tools/react-weight-estimator/; npm install
+	@cd ./web/modules/custom/react_tools/tools/react-weight-estimator/; npm run build
+
+	@echo "Building our locator map..."
+	@if [ ! -d "./web/modules/custom/react_tools/tools/react-locator-map/src/localcss/" ]; then echo "Creating Directory..." && cd ./web/modules/custom/react_tools/tools/react-locator-map/src/ && mkdir localcss; fi
+	@cd ./web/modules/custom/react_tools/tools/react-locator-map/src/sass/; sass main.scss ../localcss/main.css
+	@cd ./web/modules/custom/react_tools/tools/react-locator-map/; npm install
+	@cd ./web/modules/custom/react_tools/tools/react-locator-map/; npm run build
+
+	@echo "Building our ppm tool..."
+	@if [ ! -d "./web/modules/custom/react_tools/tools/react-ppm-tool/src/localcss/" ]; then echo "Creating Directory..." && cd ./web/modules/custom/react_tools/tools/react-ppm-tool/src/ && mkdir localcss; fi
+	@cd ./web/modules/custom/react_tools/tools/react-ppm-tool/src/sass/; sass main.scss ../localcss/main.css
+	@cd ./web/modules/custom/react_tools/tools/react-ppm-tool/; npm install
+	@cd ./web/modules/custom/react_tools/tools/react-ppm-tool/; npm run build
+
+	@echo "Building our entitlements page..."
+	@if [ ! -d "./web/modules/custom/react_tools/tools/react-entitlements-page/src/localcss/" ]; then echo "Creating Directory..." && cd ./web/modules/custom/react_tools/tools/react-entitlements-page/src/ && mkdir localcss; fi
+	@cd ./web/modules/custom/react_tools/tools/react-entitlements-page/src/sass/; sass main.scss ../localcss/main.css
+	@cd ./web/modules/custom/react_tools/tools/react-entitlements-page/; npm install
+	@cd ./web/modules/custom/react_tools/tools/react-entitlements-page/; npm run build
+
+	@echo "Clearing Drupal Caches"
+	@docker-compose run php drupal cache:rebuild all

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ps:
 	@docker ps --filter name="$(PROJECT_NAME)*"
 
 shell:
-	docker exec -ti "$(shell docker ps --filter name="$(PROJECT_NAME)_php" --format "{{ .ID }}") sh"
+	docker exec -ti $(shell docker ps --filter name='$(PROJECT_NAME)_php' --format "{{ .ID }}") sh
 
 dbdump:
 	@echo "Creating Database Dump for $(PROJECT_NAME)..."

--- a/web/themes/custom/move_mil/backstop-paths.js
+++ b/web/themes/custom/move_mil/backstop-paths.js
@@ -1,5 +1,5 @@
 var pathConfig = {};
 
-pathConfig.array = ['/','/customer-service']
+pathConfig.array = ['/','/moving-guide', '/entitlements', '/moving-guide/conus', '/moving-guide/reimbursements', '/moving-guide/claims', '/moving-guide/tips', '/moving-guide/nightmare-moves', '/moving-guide/oconus', '/moving-guide/tdy', '/moving-guide/retirees-separatees', '/moving-guide/civilians', '/service-specific-information', '/service-specific-information/marine-corps', '/service-specific-information/navy', '/service-specific-information/air-force', '/service-specific-information/coast-guard', '/tutorials', '/tutorials/returning-user-login', '/tutorials/create-a-shipment', '/tutorials/create-a-ppm-shipment', '/tutorials/dual-military-mil-to-mil-move', '/tutorials/cancel-a-shipment', '/tutorials/file-a-claim', '/faqs', 'customer-service', '/resources', '/resources/ppm-estimator', '/resources/weight-estimator', '/resources/locator-maps', 'resources/inventory-form' ]
 
 module.exports = pathConfig;


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- updates our backstopjs paths array to include all current urls as of Friday, June 15, 2018
- includes a new make build-tools command for building our react tools

## Testing

To verify the changes proposed in this pull request…

**validate backstop testing**
1. update local with the latest DB, Files, Code, and Config
2. from the theme root, npm run vis-ref to create the reference images from stage
3. from the theme root, npm run vis-test to create the test images from your local and compare to stage
4. you should be able to pass all test currently
<img width="1324" alt="screen shot 2018-06-15 at 2 23 45 pm" src="https://user-images.githubusercontent.com/37077057/41484182-dbc3c73a-70a9-11e8-93f8-de5532077752.png">

**validate make command**
1. from the project root, run make build-tools
2. to confirm, navigate to each tool directory and ensure that 
- the node_modules have been installed
- the local css directory and css files have been compiled from sass
- the build directory has been created with the tool
- navigate to the the following urls and ensure that the tools render on your local env
/entitlements
/resources/locator-maps
/resources/weight-estimator
/resources/ppm-estimator
