### PR TITLE
fully vetted IE grid alignment in weight estimator tool

### DIFF
--- a/web/modules/custom/react_tools/tools/react-weight-estimator/src/components/total.js
+++ b/web/modules/custom/react_tools/tools/react-weight-estimator/src/components/total.js
@@ -16,7 +16,7 @@ class Total extends Component {
     render() {
         return (
             <div className={"total-container "  + (this.props.isFixed ? 'fixed' : '')}>
-                <div className="total">
+                <div className="total usa-grid">
                     <div className="flex-container no-pad">
                         <div className="flex-item logo" />
                         <div className="flex-item">

--- a/web/modules/custom/react_tools/tools/react-weight-estimator/src/sass/main.scss
+++ b/web/modules/custom/react_tools/tools/react-weight-estimator/src/sass/main.scss
@@ -74,6 +74,10 @@ $total-background: #d6d7d9;
                 }
             }
         }
+
+        .room-content {
+            flex-basis: 90%;
+        }
     }
 
     .total-container{
@@ -90,9 +94,10 @@ $total-background: #d6d7d9;
             z-index: 1000;
             width: 100%;
 
-            .total{
-                margin: 0 auto;
-                max-width: 980px;
+            .total {
+                .flex-item.logo + .flex-item {
+                    flex-basis: 90%;
+                }
             }
 
             .flex-container{


### PR DESCRIPTION
Residual issues with weight estimator cleaned up.

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Puts the fixed total bar in the weight estimator into a usa-grid to ensure it aligns with rest of content.
- Completes last step needed to properly align weight estimator columns in IE10

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Build tools
1. Check tools in priority browsers (and IE10)

## Screenshots

_Attach relevant before and after screenshots here._