### PR TITLE
config change for cleaned jump link

### DIFF
--- a/config/sync/block.block.during_the_move.yml
+++ b/config/sync/block.block.during_the_move.yml
@@ -18,10 +18,10 @@ provider: null
 plugin: 'views_block:faqs-block_7'
 settings:
   id: 'views_block:faqs-block_7'
-  label: 'During the Move (Packing & Unloading)'
+  label: ''
   provider: views
   label_display: visible
-  views_label: 'During the Move (Packing & Unloading)'
+  views_label: ''
   items_per_page: none
 visibility:
   node_type:


### PR DESCRIPTION
PR to persist config changes already on live site. Completes Pivotal ticket [#158525798 - clean up "During the Move" jump link on Moving Tips page](https://www.pivotaltracker.com/story/show/158525798)

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Unchecks the "Override title" box in the "FAQs: Moving Tips Block - During the Move" block settings.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Import config
1. check the id on the second moving tips block wrapper. It should match that on the live site, `during-the-move-packing-and-unloading`. The jump link itself will not be updated though - that is content.

## Screenshots

