### PR TITLE
config change for cleaned jump link

### DIFF
--- a/config/sync/block.block.during_the_move.yml
+++ b/config/sync/block.block.during_the_move.yml
@@ -18,10 +18,10 @@ provider: null
 plugin: 'views_block:faqs-block_7'
 settings:
   id: 'views_block:faqs-block_7'
-  label: 'During the Move (Packing & Unloading)'
+  label: ''
   provider: views
   label_display: visible
-  views_label: 'During the Move (Packing & Unloading)'
+  views_label: ''
   items_per_page: none
 visibility:
   node_type:


### PR DESCRIPTION
PR to persist config changes already on live site. Completes Pivotal ticket [#158525798 - clean up "During the Move" jump link on Moving Tips page](https://www.pivotaltracker.com/story/show/158525798)

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Unchecks the "Override title" box in the "FAQs: Moving Tips Block - During the Move" block settings.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Import config
1. check the id on the second moving tips block wrapper. It should match that on the live site, `during-the-move-packing-and-unloading`. The jump link itself will not be updated though - that is content.

## Screenshots

Local with change:
<img width="1126" alt="updated config to update block id - local fixed" src="https://user-images.githubusercontent.com/29130580/42593967-d0143bfa-851b-11e8-91ff-82e84198e467.png">