### PR TITLE
adding a max body size value to our nginx proxy 

### DIFF
--- a/.ebextensions/01_nginx_proxy.confg
+++ b/.ebextensions/01_nginx_proxy.confg
@@ -1,0 +1,7 @@
+files:
+    "/etc/nginx/conf.d/proxy.conf" :
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+           client_max_body_size 20M;


### PR DESCRIPTION
This will fix errors related to uploading the larger ( <=3mb ) files for the parser. The nginx proxy which controls the connection to the load balancer to our php docker service was limiting that connection. There was a secondary config within drupal that also needs to be updated to fix this issue but this should clear it up on the ec2 side of things.


## Testing

Head to the admin parser and upload a larger than 3 mb. A drupal error, or no error should happen. Nginx should not be the limiter here.

https://bixal365-my.sharepoint.com/personal/ivonne_carrillo_bixal_com/Documents/Microsoft%20Teams%20Chat%20Files/Screen%20Shot%202018-07-12%20at%2010.56.50%20AM.png
