### PR TITLE
Circleci now builds the staging artifact on the 1.x-dev branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,6 @@ build_image: &build_image
       aws_auth:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
-        aws_default_region: $AWS_DEFAULT_REGION
   steps:
     - checkout
     - setup_remote_docker:
@@ -166,7 +165,7 @@ build_image: &build_image
           ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
     - run:
         name: "Log in to AWS ECR"
-        command: eval $(aws ecr get-login --region us-east-1)
+        command: eval $(aws ecr get-login)
     - run:
         name: "Build & Push Docker Image"
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,8 @@ build_image: &build_image
           ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
     - run:
         name: "Log in to AWS ECR"
-        command: eval "aws ecr get-login"
+        command: eval $(aws ecr get-login --region us-east-1 --no-include-email)
+
     - run:
         name: "Build & Push Docker Image"
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,27 @@ code_coverage: &code_coverage
         path: /var/www/html/artifacts
     - save_cache: *save_cache
 
+build_image: &build_image
+  <<: *defaults
+  steps:
+    - checkout
+    - restore_cache: *restore_cache
+    - run:
+        name: install aws
+        command: |
+          curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+          unzip awscli-bundle.zip
+          sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+    - run:
+        name: "Log in to AWS ECR"
+        command: eval $(aws ecr get-login)
+    - run:
+        name: "Build & Push Docker Image"
+        command: |
+          docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/move-mil:latest -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:$CIRCLE_SHA1 -f dockerfile/Dockerfile .
+          docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/move-mil:$CIRCLE_SHA1
+
+
 # Declare all of the jobs we should run.
 version: 2
 jobs:
@@ -143,6 +164,8 @@ jobs:
      <<: *code_sniffer
   code-coverage:
      <<: *code_coverage
+  build-image:
+     <<: build_image
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
@@ -153,3 +176,6 @@ workflows:
       - behat
       - code-sniffer
       - code-coverage
+  build-image:
+    jobs:
+      - build-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ build_image: &build_image
       aws_auth:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+        aws_default_region: $AWS_DEFAULT_REGION
   steps:
     - checkout
     - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,6 @@ workflows:
   build_stage_image:
     jobs:
       - build-stage-image:
-          filters:
-            branches:
-              only: 1.x-dev
+        filters:
+          branches:
+            only: 1.x-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ code_coverage: &code_coverage
 build_image: &build_image
   docker:
     - image: python:3.7.0
-    - aws_auth:
+      aws_auth:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ build_image: &build_image
           ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
     - run:
         name: "Log in to AWS ECR"
-        command: eval $(aws ecr get-login)
+        command: eval "aws ecr get-login"
     - run:
         name: "Build & Push Docker Image"
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,9 @@ code_coverage: &code_coverage
 build_image: &build_image
   docker:
     - image: python:3.7.0
+    - aws_auth:
+        aws_access_key_id: $AWS_ACCESS_KEY_ID
+        aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
   steps:
     - checkout
     - setup_remote_docker:
@@ -162,7 +165,7 @@ build_image: &build_image
           ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
     - run:
         name: "Log in to AWS ECR"
-        command: eval $(aws ecr get-login)
+        command: eval $(aws ecr get-login --region us-east-1)
     - run:
         name: "Build & Push Docker Image"
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ code_coverage: &code_coverage
         path: /var/www/html/artifacts
     - save_cache: *save_cache
 
-build_image: &build_image
+build_stage_image: &build_stage_image
   docker:
     - image: python:3.7.0
   steps:
@@ -182,18 +182,20 @@ jobs:
      <<: *code_sniffer
   code-coverage:
      <<: *code_coverage
-  build-image:
-     <<: *build_image
+  build-stage-image:
+     <<: *build_stage_image
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
   version: 2
   test_and_lint:
     jobs:
-#      - run-unit-kernel-tests
       - behat
       - code-sniffer
       - code-coverage
-  build_image:
+  build_stage_image:
     jobs:
-      - build-image
+      - build-stage-image:
+          filters:
+            branches:
+              only: 1.x-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,9 +135,6 @@ code_coverage: &code_coverage
 build_image: &build_image
   docker:
     - image: python:3.7.0
-      aws_auth:
-        aws_access_key_id: $AWS_ACCESS_KEY_ID
-        aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
   steps:
     - checkout
     - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,24 +133,41 @@ code_coverage: &code_coverage
     - save_cache: *save_cache
 
 build_image: &build_image
-  <<: *defaults
+  docker:
+    - image: python:3.7.0
   steps:
     - checkout
+    - setup_remote_docker:
+        docker_layer_caching: true
     - restore_cache: *restore_cache
+    - run:
+        name: Install dependencies
+        command: |
+          apt-get update \
+            && apt-get install -y \
+              unzip
+    - run:
+        name: Install Docker client
+        command: |
+          set -x
+          VER="18.03.1-ce"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          mv /tmp/docker/* /usr/bin
     - run:
         name: install aws
         command: |
           curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
           unzip awscli-bundle.zip
-          sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+          ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
     - run:
         name: "Log in to AWS ECR"
         command: eval $(aws ecr get-login)
     - run:
         name: "Build & Push Docker Image"
         command: |
-          docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/move-mil:latest -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:$CIRCLE_SHA1 -f dockerfile/Dockerfile .
-          docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/move-mil:$CIRCLE_SHA1
+          docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:stage -f docker/Dockerfile .
+          docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:stage
 
 
 # Declare all of the jobs we should run.
@@ -165,7 +182,7 @@ jobs:
   code-coverage:
      <<: *code_coverage
   build-image:
-     <<: build_image
+     <<: *build_image
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
@@ -176,6 +193,6 @@ workflows:
       - behat
       - code-sniffer
       - code-coverage
-  build-image:
+  build_image:
     jobs:
       - build-image


### PR DESCRIPTION


## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request creates a build step to build and push our docker image to aws ecr automatically on 1.x-dev merges

## Testing

To verify the changes proposed in this pull request this pull request should trigger the 4th build job.
