### PR TITLE
Removed archive banner div, left comment in place with link to Pivota…

### DIFF
--- a/web/themes/custom/move_mil/templates/layout/page--front.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page--front.html.twig
@@ -20,12 +20,8 @@
   </section>
   {% endif %}
 
-  <div class="archive-banner">
-    <div class="usa-grid">
-      <p><b>Welcome to the new Move.mil!</b> Can’t find what you’re looking for? Legacy content can be found at <a href="https://archive.move.mil">archive.move.mil</a>.</p>
-    </div>
-  </div>
-
+  {# Archive Banner Link was here -- Pivotal: https://www.pivotaltracker.com/story/show/159035314 #}
+  
   {% if header_basic %}
   <div class="usa-nav-container">
   {% endif %}


### PR DESCRIPTION
@rich-allen-gov and @ivonne-gov  -- **BIG NOTE: THIS PR CANNOT BE MERGED IN UNTIL TOMORROW, JULY 31st 2018. **

## Summary of Changes

This pull request…

- Was to remove the banner on the homepage linking users to archive.move.mil. This archive site is no longer running as of July 31, 2018 -- so the link from Move.mil is to be removed.

## Testing

To verify the changes proposed in this pull request…

1. 

1. Navigate to homepage of Move.mil
2. Verify the blue archive banner is no longer present.

## Screenshots
