### PR TITLE
Apparently this archive header appears whenever you don't want it to. 

### DIFF
--- a/web/themes/custom/move_mil/templates/layout/page.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page.html.twig
@@ -20,11 +20,7 @@
   </section>
   {% endif %}
 
-  <div class="archive-banner">
-    <div class="usa-grid">
-      <p><b>Welcome to the new Move.mil!</b> Can’t find what you’re looking for? Legacy content can be found at <a href="https://archive.move.mil">archive.move.mil</a>.</p>
-    </div>
-  </div>
+  {# Archive Banner Link was here -- Pivotal: https://www.pivotaltracker.com/story/show/159035314 #}
 
   {% if header_basic %}
   <div class="usa-nav-container">


### PR DESCRIPTION
Removed the archive link from page.html.twig, because it was apparently there as well?