### PR TITLE
remove link from text-with-image paragraph where no link exists

### DIFF
--- a/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
+++ b/web/themes/custom/move_mil/templates/system/paragraph/paragraph--text-with-image.html.twig
@@ -25,7 +25,11 @@
           <div class="usa-media_block-img usa-media_block-img__align-{{ imageAlignment }} usa-width-one-third">
 
             {% if content.field_image|field_value == true %}
-              <a href="{{ titleLink }}">{{ content.field_image }}</a>
+              {% if titleLink is not empty %}
+                <a href="{{ titleLink }}">{{ content.field_image }}</a>
+              {% else %}
+                {{ content.field_image }}
+              {% endif %}
             {% elseif content.field_image|field_value == false and content.field_plain_title|field_value == true %}
               {% if titleLink is not empty %}
                 <h3 class="field-title-plain--link"><a href="{{ titleLink }}">{{ content.field_plain_title.0 }}</a></h3>


### PR DESCRIPTION
This simple Twig change completes [Pivotal ticket #158555908 - homepage icons should not be links](https://www.pivotaltracker.com/story/show/158555908).

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- In Twig, checks if a link exists associated with image/title of "Text with Image" paragraph type and doesn't include an `a` tag if it doesn't.

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. Icons on Home page section below the hero should not act like links on hover

## Screenshots

(Cannot upload .webm video - check Pivotal)