### PR TITLE
Fix PPM and Locations files parser tmp path

### DIFF
--- a/web/modules/custom/parser/src/Form/FilesAndTablesManagerForm.php
+++ b/web/modules/custom/parser/src/Form/FilesAndTablesManagerForm.php
@@ -145,6 +145,7 @@ class FilesAndTablesManagerForm extends ConfigFormBase {
 
     $form['zip_3']['file'] = [
       '#type' => 'managed_file',
+      '#upload_location' => 'public://',
       '#title' => $this->t('Zip_3'),
       '#upload_validators' => [
         'file_validate_extensions' => ['csv'],
@@ -170,6 +171,7 @@ class FilesAndTablesManagerForm extends ConfigFormBase {
 
     $form['zip_5']['file'] = [
       '#type' => 'managed_file',
+      '#upload_location' => 'public://',
       '#title' => $this->t('Zip_5'),
       '#upload_validators' => [
         'file_validate_extensions' => ['csv'],
@@ -195,6 +197,7 @@ class FilesAndTablesManagerForm extends ConfigFormBase {
 
     $form['400NG']['file'] = [
       '#type' => 'managed_file',
+      '#upload_location' => 'public://',
       '#title' => $this->t('400NG'),
       '#upload_validators' => [
         'file_validate_extensions' => ['xlsx'],
@@ -243,6 +246,7 @@ class FilesAndTablesManagerForm extends ConfigFormBase {
 
     $form['entitlements']['file'] = [
       '#type' => 'managed_file',
+      '#upload_location' => 'public://',
       '#title' => $this->t('Entitlements'),
       '#upload_validators' => [
         'file_validate_extensions' => ['yml'],
@@ -267,6 +271,7 @@ class FilesAndTablesManagerForm extends ConfigFormBase {
 
     $form['discounts']['file'] = [
       '#type' => 'managed_file',
+      '#upload_location' => 'public://',
       '#title' => $this->t('Discount'),
       '#upload_validators' => [
         'file_validate_extensions' => ['xlsx'],
@@ -296,6 +301,7 @@ class FilesAndTablesManagerForm extends ConfigFormBase {
 
     $form['zipcodes']['file'] = [
       '#type' => 'managed_file',
+      '#upload_location' => 'public://',
       '#title' => $this->t('Zipcodes'),
       '#upload_validators' => [
         'file_validate_extensions' => ['csv'],
@@ -322,6 +328,7 @@ class FilesAndTablesManagerForm extends ConfigFormBase {
 
     $form['locations']['file'] = [
       '#type' => 'managed_file',
+      '#upload_location' => 'public://',
       '#title' => $this->t('Locations'),
       '#upload_validators' => [
         'file_validate_extensions' => ['txt'],


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request…

- For the custom form that we implemented to upload/parse PPM and Locator files, the /tmp location is not optimal on stage and production. Because we have at least 2 instances and the file will be uploaded only to one instance, causing intermittent 'file not found' errors. So now, the file location will be the public /sites/default/files, that is share for all the resources,
- the change is only in that form /admin/config/parser/manager

## Testing

To verify the changes proposed in this pull request…

1. Pull changes
1. clear caches
1. go to  /admin/config/parser/manager
1. upload a file and submit several times, of different types.
1. The file should be upload, read, parse and write in the desired database table.
