### PR TITLE
Feature/158925013/remove html tags

### DIFF
--- a/config/sync/core.entity_form_display.node.location.default.yml
+++ b/config/sync/core.entity_form_display.node.location.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.location.field_location_hours
     - field.field.node.location.field_location_link
     - field.field.node.location.field_location_note
+    - field.field.node.location.field_location_notes
     - field.field.node.location.field_location_reference
     - field.field.node.location.field_location_services
     - field.field.node.location.field_location_telephone
@@ -21,7 +22,6 @@ dependencies:
     - link
     - paragraphs
     - path
-    - text
 id: node.location.default
 targetEntityType: node
 bundle: location
@@ -77,13 +77,13 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
-  field_location_note:
+  field_location_notes:
     weight: 16
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
+    type: string_textarea
     region: content
   field_location_reference:
     weight: 17
@@ -175,4 +175,5 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_location_note: true

--- a/config/sync/core.entity_view_display.node.location.default.yml
+++ b/config/sync/core.entity_view_display.node.location.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.location.field_location_hours
     - field.field.node.location.field_location_link
     - field.field.node.location.field_location_note
+    - field.field.node.location.field_location_notes
     - field.field.node.location.field_location_reference
     - field.field.node.location.field_location_services
     - field.field.node.location.field_location_telephone
@@ -20,7 +21,6 @@ dependencies:
     - entity_reference_revisions
     - geolocation
     - link
-    - text
     - user
 id: node.location.default
 targetEntityType: node
@@ -77,12 +77,12 @@ content:
     third_party_settings: {  }
     type: link
     region: content
-  field_location_note:
+  field_location_notes:
     weight: 9
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    type: basic_string
     region: content
   field_location_reference:
     weight: 10
@@ -122,4 +122,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_location_note: true

--- a/config/sync/field.field.node.location.field_location_notes.yml
+++ b/config/sync/field.field.node.location.field_location_notes.yml
@@ -1,0 +1,19 @@
+uuid: 70f5ee66-fdd5-49d6-8833-4cb99e770a23
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_location_notes
+    - node.type.location
+id: node.location.field_location_notes
+field_name: field_location_notes
+entity_type: node
+bundle: location
+label: 'Location notes'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.storage.node.field_location_notes.yml
+++ b/config/sync/field.storage.node.field_location_notes.yml
@@ -1,0 +1,19 @@
+uuid: 6299807b-2f38-4c65-98cb-dcd00c479aa5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_location_notes
+field_name: field_location_notes
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/parser/console.services.yml
+++ b/web/modules/custom/parser/console.services.yml
@@ -9,3 +9,8 @@ services:
     arguments: ['@database', '@entity_type.manager']
     tags:
       - { name: drupal.command }
+  parser.notes:
+    class: Drupal\parser\Command\NotesCommand
+    arguments: ['@database', '@entity_type.manager']
+    tags:
+      - { name: drupal.command }

--- a/web/modules/custom/parser/parser.links.menu.yml
+++ b/web/modules/custom/parser/parser.links.menu.yml
@@ -1,6 +1,6 @@
 parser.files_and_tables_manager_form:
-  title: 'Parser admin (PPM tool data manager)'
+  title: 'Parser admin (PPM/Locator tool data manager)'
   route_name: parser.files_and_tables_manager_form
-  description: 'Upload files so their data can be used for the endpoints to be consumed by the PPM tool'
+  description: 'Upload files so their data can be used for the endpoints to be consumed by the PPM tool and Locator Maps'
   parent: system.admin_config_system
   weight: 99

--- a/web/modules/custom/parser/src/Command/NotesCommand.php
+++ b/web/modules/custom/parser/src/Command/NotesCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\parser\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\Core\Database\Driver\mysql\Connection;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
+use Drupal\Console\Core\Style\DrupalStyle;
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+
+/**
+ * Class NotesCommand.
+ *
+ * @Drupal\Console\Annotations\DrupalCommand (
+ *     extension="parser",
+ *     extensionType="module"
+ * )
+ */
+class NotesCommand extends ContainerAwareCommand {
+
+  /**
+   * Drupal\Core\Database\Driver\mysql\Connection definition.
+   *
+   * @var \Drupal\Core\Database\Driver\mysql\Connection
+   */
+  protected $database;
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManager definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new NotesCommand object.
+   */
+  public function __construct(Connection $database, EntityTypeManager $entityTypeManager) {
+    $this->database = $database;
+    $this->entityTypeManager = $entityTypeManager;
+    parent::__construct();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this
+      ->setName('notes')
+      ->setDescription($this->trans('commands.notes.description'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $io = new DrupalStyle($input, $output);
+    $io->text("Copying CKeditor notes to PlainText notes.");
+    try {
+      $locations = $this->entityTypeManager
+        ->getStorage('node')
+        ->loadByProperties([
+          'type' => 'location',
+        ]);
+    }
+    catch (InvalidPluginDefinitionException $ipde) {
+      $io->error('Exception on location node, ' . $ipde->getMessage());
+      exit(-1);
+    }
+    $locationsCount = 0;
+    foreach ($locations as $location) {
+      if (!empty($location)) {
+        $oldNoteField = $location
+          ->get('field_location_note')
+          ->getValue();
+        if (empty($oldNoteField)) {
+          continue;
+        }
+        $htmlNote = $oldNoteField[0]['value'];
+        $notes = strip_tags($htmlNote);
+        $location->set('field_location_notes', $notes);
+        try {
+          $location->save();
+        }
+        catch (EntityStorageException $e) {
+          $io->error('An error occurred while trying to update the location entity, ' . $e->getMessage());
+          exit(-1);
+        }
+        $io->text($location->label() . ' notes ' . $notes);
+        $locationsCount++;
+      }
+    }
+    $io->success($locationsCount . ' locations changed successful');
+  }
+
+}

--- a/web/modules/custom/parser/src/Controller/LocationsController.php
+++ b/web/modules/custom/parser/src/Controller/LocationsController.php
@@ -139,7 +139,7 @@ class LocationsController extends ControllerBase {
       $res = $client->request('GET', $request);
     }
     catch (GuzzleException $ge) {
-      $this->errors[] = 'There was an network problem. Mind trying again?';
+      $this->errors[] = 'There was a network problem. Mind trying again?';
       return NULL;
     }
     $data = json_decode($res->getBody()->getContents(), JSON_OBJECT_AS_ARRAY);
@@ -288,7 +288,7 @@ class LocationsController extends ControllerBase {
       ->get('field_location_link')
       ->getValue();
     $data['notes'] = $entity
-      ->get('field_location_note')
+      ->get('field_location_notes')
       ->getValue();
     $data['services'] = $entity
       ->get('field_location_services')


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.


## Summary of Changes

This pull request…

- Address this ticket https://www.pivotaltracker.com/story/show/158925013
- Adds a new notes field, not just as plain-text field.
- Hides the old note field, so we still have it for making the field values migration.
- Add a command that will copy the value of the old note field, strip the HTML tags and then save that value to the new plain-text field.
- Update the Locations controller so now it reads from the new notes field.

## Testing

To verify the changes proposed in this pull request…

1. Pull changes
1. run configuration import  and clear caches
1. execute this command in your local: `docker-compose run php drupal notes`
1. On staging or production execute: `sudo docker exec -it [container name] vendor/bin/drupal notes` instead.
1. Clear caches
1. Edit a location that you know it has notes like "LUKE AFB" or "Keesler AFB", you should see the new field notes, and it should be plain-text and it should have a value.
1. Go to Locator Map and look for a location that use to have HTML tags like "LUKE AFB" or "Barksdale". They should not have HTML tags.

## Screenshots

https://cl.ly/002s2M2G0N22