### PR TITLE
Use zip5 ‘service_area’ column name instead of wrong one ‘rate_area’

### DIFF
--- a/web/modules/custom/parser/src/Controller/PpmEstimatorController.php
+++ b/web/modules/custom/parser/src/Controller/PpmEstimatorController.php
@@ -446,9 +446,9 @@ class PpmEstimatorController extends ControllerBase {
    */
   private function otherCharges($start_service_area, $end_service_area, $year, $weight, $cwt) {
     $charges = $start_service_area['orig_dest_service_charge'] + $end_service_area['orig_dest_service_charge'];
-    $pack = floatval($this->packunpack($start_service_area, $year, $weight));
-    $unpack = floatval($this->packunpack($end_service_area, $year));
-    $packunpack = $pack['pack'] + $unpack['unpack'];
+    $pack = $this->packunpack($start_service_area, $year, $weight);
+    $unpack = $this->packunpack($end_service_area, $year);
+    $packunpack = floatval($pack['pack']) + floatval($unpack['unpack']);
     $charges += $packunpack;
     return $charges * $cwt;
   }

--- a/web/modules/custom/parser/src/Controller/PpmEstimatorController.php
+++ b/web/modules/custom/parser/src/Controller/PpmEstimatorController.php
@@ -460,7 +460,7 @@ class PpmEstimatorController extends ControllerBase {
     $area = $start_zip3['rate_area'];
     if ($area === 'ZIP') {
       $zip5 = $this->zip5($start_zipcode);
-      $area = $zip5['rate_area'];
+      $area = $zip5['service_area'];
     }
     if ($start_zip3['state'] == $end_zip3['state']) {
       $region = 15;


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- Changes the query to the zip5 table. Instead of fetching the column `rate_area` which does not exist, now it is fetching the correct column name `service_area`.
- Cast to float the pack and unpack array values instead of the array. Casting the array to float is making the array null. Then the pack and unpack values are equal to 0. That was clearly a mistake, I meant to cast the values from the array. It's fixed now.

## Testing

To verify the changes proposed in this pull request…

1. pull branch changes and clear caches.
1. Use the PPM tool with the following data
```
{
    "selectedEntitlement": "o-3-w-3",
    "isDependencies": true,
    "locations": {
        "origin": "93230",
        "destination": "78236"
    },
    "weightOptions": {
        "houseHold": "6000",
        "proGear": "0",
        "dependent": "0"
    },
    "selectedMoveDate": "2018-08-22T17:00:45.527Z"
}
```

The results must be 
```
{
    "incentive": {
        "min": 3300,
        "max": 3900
    },
    "advancePayment": {
        "min": 1980,
        "max": 2340,
        "percentage": 60
    }
}
```

## Screenshots

<img width="533" alt="screen shot 2018-08-15 at 8 32 00 pm" src="https://user-images.githubusercontent.com/37001835/44180488-bb3d6100-a0ca-11e8-8b87-291b6c221b5e.png">
