### PR TITLE
Remove jumplinks block on Service Specific Information pages

### DIFF
--- a/config/sync/block.block.jumplinks.yml
+++ b/config/sync/block.block.jumplinks.yml
@@ -21,6 +21,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
+    pages: "<front>\r\n/service-specific-information/\r\n/service-specific-information/*"
     negate: true
     context_mapping: {  }


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.

## Summary of Changes

This pull request…

- Address pivotal ticket https://www.pivotaltracker.com/story/show/159927157
- adjust the configuration of the jumplink block display -- it was displaying on the service specific information pages, and we did not want that.

## Testing

To verify the changes proposed in this pull request…

1. pull changes and clear caches
1. import configuration
1. go to the site as an admin user
1. go to Structure -> Block layout
1. go to jumplinks config 
1. select restricted pages, and `service specific information pages` should be there
