### PR TITLE
preprocess and template for conditional site slogan for SME page

### DIFF
--- a/web/themes/custom/move_mil/preprocess/block/block__system_branding_block.preprocess.inc
+++ b/web/themes/custom/move_mil/preprocess/block/block__system_branding_block.preprocess.inc
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Preprocess function for this hook.
+ */
+
+/**
+ * Implements hook_preprocess_block__DELTA__REGION().
+ *
+ * This made possible by our custom theme suggestion.
+ * @see uswds_theme_suggestions_block_alter().
+ */
+function move_mil_preprocess_block__system_branding_block(&$variables) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof \Drupal\node\NodeInterface) {
+    $variables['nid'] = $node->id();
+  }
+}

--- a/web/themes/custom/move_mil/templates/system/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/move_mil/templates/system/block/block--system-branding-block.html.twig
@@ -36,7 +36,11 @@
     {% if site_slogan == true %}
       <h2 class="usa-font-lead">{{ site_slogan }}</h2>
       {% elseif site_logo == false %}
-      <span class="usa-font-lead"> Official <abbr title="Department of Defense">DOD</abbr> Moving Portal</span>
+        {% if nid == '928' %} <!-- SME page slogan -->
+          <span class="usa-font-lead"> Official <abbr title="Department of Defense">DOD</abbr> PPSO & TSP Moving Portal</span>
+        {% else %}
+          <span class="usa-font-lead"> Official <abbr title="Department of Defense">DOD</abbr> Customer Moving Portal</span>
+        {% endif %}
     {% endif %}
   </div>
 


### PR DESCRIPTION
Executes [Pivotal ticket #159407375 - different site title/subtitle on SME page vs. other pages](https://www.pivotaltracker.com/story/show/159407375).

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Adds a preprocess exposing the node id to the block containing the site title/slogan
- Leverages that node id within a new block template to generate the slogan conditionally based on the value of that node id

## Testing

To verify the changes proposed in this pull request…

1. Pull code, clear cache
1. Go to `/sme` to see the new subtitle `Official DoD PPSO & TSP Moving Portal`
1. Go to any other page to see the updated subtitle `Official DoD Customer Moving Portal`

## Screenshots

[See ticket for screenshots.](https://www.pivotaltracker.com/story/show/159407375)