### PR TITLE
fix login banner config to match prod site

### DIFF
--- a/config/sync/block.block.move_mil_login_banner.yml
+++ b/config/sync/block.block.move_mil_login_banner.yml
@@ -1,9 +1,9 @@
-uuid: 8cc6b3a4-ce0d-4cf9-aa7b-5c0b122aac7a
+uuid: 6ac99abf-f7a3-49d9-8eeb-46e624ebee91
 langcode: en
 status: true
 dependencies:
   content:
-    - 'block_content:basic:3dc8e15e-7f60-4205-a577-1b0ea644db79'
+    - 'block_content:basic:7209d37f-9903-4ef2-9455-9f140eaaccf5'
   module:
     - block_content
   theme:
@@ -13,9 +13,9 @@ theme: move_mil
 region: hero
 weight: 0
 provider: null
-plugin: 'block_content:3dc8e15e-7f60-4205-a577-1b0ea644db79'
+plugin: 'block_content:7209d37f-9903-4ef2-9455-9f140eaaccf5'
 settings:
-  id: 'block_content:3dc8e15e-7f60-4205-a577-1b0ea644db79'
+  id: 'block_content:7209d37f-9903-4ef2-9455-9f140eaaccf5'
   label: 'Login Banner Block'
   provider: block_content
   label_display: '0'


### PR DESCRIPTION
Simple PR......ensures changes to the login banner per https://www.pivotaltracker.com/story/show/160450775 will persist upon future deployments. Change made in consultation with @ivonne-gov.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Integrates config related to the newly-created Login Banner Block from the production site (via a db dump and partial export) into the code base.
- A previous commit/PR had created this block, but it did not match settings for new blocks when created and placed on the staging or prod sites, so an error resulted and had to be fixed on each.

## Testing

(probably not needed, but.....)
To verify the changes proposed in this pull request…

1. Pull code
1. Import production db
1. Import config
1. The block in question should look identical to the [live site](https://move.mil/) on all pages.

## Screenshots

Live:
<img width="1159" alt="screen shot 2018-10-02 at 5 12 34 pm" src="https://user-images.githubusercontent.com/29130580/46377365-621f9180-c666-11e8-806b-ed9ec8ab9f9e.png">

Local:
<img width="1097" alt="screen shot 2018-10-02 at 5 13 22 pm" src="https://user-images.githubusercontent.com/29130580/46377405-7e233300-c666-11e8-92be-7d7a9342ac82.png">
