### PR TITLE
Location address fixes on locator map

### DIFF
--- a/config/sync/field.field.node.location.field_location_address.yml
+++ b/config/sync/field.field.node.location.field_location_address.yml
@@ -32,4 +32,5 @@ settings:
     additionalName: '0'
     familyName: '0'
   langcode_override: ''
+  field_overrides: {  }
 field_type: address

--- a/web/modules/custom/react_tools/tools/apps/react-locator-map/src/components/listItem.js
+++ b/web/modules/custom/react_tools/tools/apps/react-locator-map/src/components/listItem.js
@@ -114,21 +114,21 @@ this.showHours = (hours) =>{
 }
 
 this.renderLocationItem = (location) =>{
-  if(location.address_line || 
-     location.address_line2 || 
-     location.locality || 
-     location.administrative_area || 
-     location.postal_code || 
+  if(location.address_line1 ||
+     location.address_line2 ||
+     location.locality ||
+     location.administrative_area ||
+     location.postal_code ||
      location.country_code){
      return (
         <div>
           <div className="bold-header">Location</div>
           <div>
-            <LocationItem item={location.address_line} comma={true} />
+            <LocationItem item={location.address_line1} comma={!!location.address_line2} />
             <LocationItem item={location.address_line2} />
           </div>
           <div>
-            <LocationItem item={location.locality} comma={true}/>
+            <LocationItem item={location.locality} comma={!!location.administrative_area}/>
             <LocationItem item={location.administrative_area} />
             <LocationItem item={location.postal_code}/>
           </div>
@@ -141,7 +141,7 @@ this.renderLocationItem = (location) =>{
 }
 
 const LocationItem = (props) => {
-  if (!props.item){
+  if (!props.item || !props.item.length){
     return null;
   }
 
@@ -173,7 +173,7 @@ const ShippingOffice = (props) =>{
               <div className="usa-width-one-third">
                 {this.showEmails(props.office.email_addresses)}
               </div>
-              
+
               <div className="usa-width-one-third">
                 {this.showWebsites(props.office.websites)}
               </div>
@@ -187,14 +187,14 @@ const ShippingOffice = (props) =>{
 
 const ListItem = (props) => {
   let officeTypeClass = props.item.type.replace(' ', '-').toLowerCase();
-  
+
   return (
     <li>
         <div className={`${"location-search-result " + officeTypeClass}`}
           data-latitude={props.item.location.geolocation.lat}
-          data-longitude={props.item.location.geolocation.lng} 
-          data-name={props.item.title} 
-          data-type={props.item.type} 
+          data-longitude={props.item.location.geolocation.lng}
+          data-name={props.item.title}
+          data-type={props.item.type}
           id={props.item.id}>
 
           <div className="location-search-result-header">


### PR DESCRIPTION
This PR primarily fixes a heretofore unnoticed bug that was hiding the first line of addresses from locations in Locator Map results. 

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Changes the address field name in the ListItem partial to address1, matching the correct format
- Makes the comma after the first address field conditional upon existence of text in the second address field. Also does the same with the comma between city and state, but this should not have a functional effect since state is required.

## Testing

To verify the changes proposed in this pull request…

1. Pull code, build React tool assets
1. Search for any valid location. Ex: "New London"
1. Each result item should contain full addresses including a street name, and commas should never be at the end of a line.

## Screenshots

Live site (broken):
<img width="452" alt="screen shot 2018-10-03 at 1 02 57 pm" src="https://user-images.githubusercontent.com/29130580/46426480-baa96a00-c70c-11e8-9563-405924917ce8.png">

Local (partially fixed):
<img width="279" alt="screen shot 2018-10-03 at 11 56 40 am" src="https://user-images.githubusercontent.com/29130580/46426490-bf6e1e00-c70c-11e8-9570-d76a5c6b23d3.png">

Local (fully fixed):
<img width="630" alt="screen shot 2018-10-03 at 1 04 29 pm" src="https://user-images.githubusercontent.com/29130580/46426550-e7f61800-c70c-11e8-9da0-c26c0c7582d9.png">

<img width="358" alt="screen shot 2018-10-03 at 1 04 34 pm" src="https://user-images.githubusercontent.com/29130580/46426562-efb5bc80-c70c-11e8-8898-704adaf671ec.png">

