### PR TITLE
Further development of new SME page

### DIFF
--- a/config/sync/core.entity_form_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_form_display.node.sme_document.default.yml
@@ -20,45 +20,46 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   field_document_archive_date:
-    weight: 124
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_document_file:
-    weight: 125
+    weight: 3
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
     type: file_generic
     region: content
   field_document_id:
-    weight: 122
+    weight: 1
     settings:
+      size: 30
       placeholder: ''
     third_party_settings: {  }
-    type: number
+    type: string_textfield
     region: content
   field_document_updated_date:
-    weight: 123
+    weight: 11
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_sme_section:
-    weight: 126
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   node_class:
     type: string_textfield
-    weight: 35
+    weight: 9
     region: content
     settings:
       size: 60
@@ -66,7 +67,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -74,26 +75,26 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 6
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
+    weight: 10
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 7
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -101,7 +102,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/sync/core.entity_view_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.default.yml
@@ -22,29 +22,29 @@ content:
     type: datetime_default
     weight: 4
     region: content
-    label: above
+    label: inline
     settings:
       format_type: medium
       timezone_override: ''
     third_party_settings: {  }
   field_document_file:
-    weight: 3
+    weight: 5
     label: above
-    settings: {  }
+    settings:
+      use_description_as_link_text: true
     third_party_settings: {  }
-    type: file_url_plain
+    type: file_default
     region: content
   field_document_id:
     weight: 1
-    label: inline
+    label: above
     settings:
-      thousand_separator: ''
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
-    type: number_integer
+    type: string
     region: content
   field_document_updated_date:
-    weight: 2
+    weight: 3
     label: inline
     settings:
       timezone_override: ''
@@ -54,7 +54,7 @@ content:
     region: content
   field_sme_section:
     type: entity_reference_label
-    weight: 5
+    weight: 2
     region: content
     label: above
     settings:

--- a/config/sync/core.entity_view_display.node.sme_document.teaser.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.teaser.yml
@@ -28,22 +28,21 @@ content:
       use_description_as_link_text: true
     third_party_settings: {  }
   field_document_id:
-    type: number_integer
+    type: string
     weight: 0
     region: content
-    label: inline
+    label: hidden
     settings:
-      thousand_separator: ''
-      prefix_suffix: true
+      link_to_entity: false
     third_party_settings: {  }
   field_document_updated_date:
-    type: datetime_default
+    type: datetime_custom
     weight: 1
     region: content
-    label: inline
+    label: hidden
     settings:
-      format_type: medium
       timezone_override: ''
+      date_format: j/n/Y
     third_party_settings: {  }
 hidden:
   field_document_archive_date: true

--- a/config/sync/field.field.node.sme_document.field_document_id.yml
+++ b/config/sync/field.field.node.sme_document.field_document_id.yml
@@ -1,4 +1,4 @@
-uuid: b728c1f6-93d7-4b7d-a4f1-5ca0539a1747
+uuid: 60a12890-a2e3-43f1-aa94-0d61f6616182
 langcode: en
 status: true
 dependencies:
@@ -15,9 +15,5 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings:
-  min: 0
-  max: null
-  prefix: ''
-  suffix: ''
-field_type: integer
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_document_file.yml
+++ b/config/sync/field.storage.node.field_document_file.yml
@@ -11,7 +11,7 @@ entity_type: node
 type: file
 settings:
   display_field: true
-  display_default: false
+  display_default: true
   uri_scheme: public
   target_type: file
 module: file

--- a/config/sync/field.storage.node.field_document_id.yml
+++ b/config/sync/field.storage.node.field_document_id.yml
@@ -1,4 +1,4 @@
-uuid: d026c9a1-b9fb-46ed-b22b-ad831eed356c
+uuid: 7df5dce5-772c-44f5-a410-a2bceca5ca4f
 langcode: en
 status: true
 dependencies:
@@ -7,10 +7,11 @@ dependencies:
 id: node.field_document_id
 field_name: field_document_id
 entity_type: node
-type: integer
+type: string
 settings:
-  unsigned: false
-  size: normal
+  max_length: 30
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
 cardinality: 1

--- a/config/sync/views.view.sme_section.yml
+++ b/config/sync/views.view.sme_section.yml
@@ -61,10 +61,26 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: none
+        type: full
         options:
-          items_per_page: 0
+          items_per_page: 10
           offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 5
       style:
         type: html_list
         options:
@@ -216,11 +232,13 @@ display:
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
+      use_ajax: true
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -232,11 +250,150 @@ display:
     display_options:
       display_extenders: {  }
       display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+        field_sme_section_target_id:
+          id: field_sme_section_target_id
+          table: node__field_sme_section
+          field: field_sme_section_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            15: 15
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+        pager: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 5
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -370,6 +527,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -504,6 +662,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -638,6 +797,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -772,6 +932,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -906,6 +1067,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1040,6 +1202,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1189,6 +1352,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1323,6 +1487,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1457,6 +1622,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1591,6 +1757,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1725,6 +1892,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1859,6 +2027,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1993,6 +2162,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -2142,6 +2312,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -2274,6 +2445,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url.query_args
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -2292,6 +2464,7 @@ display:
         filters: false
         filter_groups: false
         sorts: false
+        pager: false
       display_description: ''
       filters:
         status:
@@ -2375,11 +2548,153 @@ display:
             label: ''
           granularity: minute
           plugin_id: datetime
+      pager:
+        type: none
+        options:
+          offset: 0
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  pov_page:
+    display_plugin: page
+    id: pov_page
+    display_title: 'POV Page'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Privately Owned Vehicles (POVs)'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        css_class: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            21: 21
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      path: moving-guide/pov
+      css_class: pov-page
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
+++ b/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
@@ -13,5 +13,6 @@
    $node = $variables['node'];
    $file = $node->get('field_document_file')->entity;
    $size = $file->getSize();
-   $variables['filesize'] = format_size($size);
+   $variables['file_url'] = file_create_url($file->getFileUri());
+   $variables['file_size'] = format_size($size);
  }

--- a/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
+++ b/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Preprocess function for this hook.
+ */
+
+/**
+ * Implements hook_preprocess_node().
+ */
+
+ function move_mil_preprocess_node__sme_document__teaser(&$variables){
+   $node = $variables['node'];
+   $file = $node->get('field_document_file')->entity;
+   $size = $file->getSize();
+   $variables['filesize'] = format_size($size);
+ }

--- a/web/themes/custom/move_mil/scss/03-organisms/_view-sme-section.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_view-sme-section.scss
@@ -1,0 +1,27 @@
+.view-sme-section {
+  ul.document-list {
+    list-style: none;
+    padding-left: 0;
+    margin-left: 0;
+    li.document-item {
+      margin-bottom: 1.5rem;
+
+      .node--type-sme-document {
+        display: flex;
+        justify-content: space-between;
+
+        .field--name-field-document-id {
+          flex: 0 0 75px;
+        }
+
+        .doc-link-size-wrapper {
+          flex-grow: 1;
+
+          &:first-child {
+            padding-left: 75px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
+++ b/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
@@ -87,11 +87,8 @@
   {{ content.field_document_id }}
 
   <div class="doc-link-size-wrapper">
-    <h3{{ title_attributes }}>
-      <a class="document-link" href="{{ file_url(content.field_document_file[0]['#file'].uri.value) }}" title="Download file">{{ label }}</a>
-      <span class="file-size">[{{ filesize }}]</span>
-        <!-- [{{ content.field_document_file[0]['#file'].filesize.value|number_format ~ ' bytes'|t }}] -->
-    </h3>
+    <a class="document-link" href="{{ file_url }}" title="Download file">{{ label.0 }}</a>
+    <span class="file-size">[{{ file_size }}]</span>
   </div>
 
   {{ content.field_document_updated_date }}

--- a/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
+++ b/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
@@ -84,15 +84,16 @@
 {{ attach_library('classy/node') }}
 <article{{ attributes.addClass(classes) }}>
 
-  <div class="document-link">
+  {{ content.field_document_id }}
+
+  <div class="doc-link-size-wrapper">
     <h3{{ title_attributes }}>
-      <a href="{{ file_url(content.field_document_file[0]['#file'].uri.value) }}" title="Download file">{{ label }}</a>
+      <a class="document-link" href="{{ file_url(content.field_document_file[0]['#file'].uri.value) }}" title="Download file">{{ label }}</a>
+      <span class="file-size">[{{ filesize }}]</span>
+        <!-- [{{ content.field_document_file[0]['#file'].filesize.value|number_format ~ ' bytes'|t }}] -->
     </h3>
   </div>
 
-  {{ content|without('field_document_file') }}
-  <div class="file-size">
-    <span class="field-label">File Size: </span><span class="field-value">{{ content.field_document_file[0]['#file'].filesize.value|number_format ~ ' bytes'|t }}</span>
-  </div>
+  {{ content.field_document_updated_date }}
 
 </article>


### PR DESCRIPTION
Continues work on Pivotal story [#161923738 - new dynamic SME page](https://www.pivotaltracker.com/story/show/161923738).

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Converts the Document ID field from a number field to a more flexible text field
- Adds a node preprocess to display the document file size in a more friendly format
- Reworks the relevant document template file and related scss file to make item theming match preliminary specs 
- Adds a pager to each SME section block appearing on the landing page

## Testing

To verify the changes proposed in this pull request…

1. Pull code, import config and rebuild theme css
1. IF YOU HAVEN'T YET: Create new Basic page with custom url `/sme-page`; add SME Section taxonomy terms; create corresponding Menu items; add documents to test.
1. Add >10 docs to a particular section to test pager

## Screenshots

Local:
<img width="802" alt="sme page with basic theming - local" src="https://user-images.githubusercontent.com/29130580/49465472-bb718180-f7cb-11e8-94dd-e96f6401a221.png">
