### PR TITLE
create POV block in FAQs view and place it on FAQ and POV pages

### DIFF
--- a/config/sync/block.block.faq_section_pov_shipments.yml
+++ b/config/sync/block.block.faq_section_pov_shipments.yml
@@ -1,0 +1,38 @@
+uuid: 06d2c4af-cf0e-48e9-84b1-15fd79c0ccb4
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.faqs
+  module:
+    - node
+    - system
+    - views
+  theme:
+    - move_mil
+id: faq_section_pov_shipments
+theme: move_mil
+region: content
+weight: -10
+provider: null
+plugin: 'views_block:faqs-block_9'
+settings:
+  id: 'views_block:faqs-block_9'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  node_type:
+    id: node_type
+    bundles:
+      page: page
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+  request_path:
+    id: request_path
+    pages: "/faqs\r\n/pov"
+    negate: false
+    context_mapping: {  }

--- a/config/sync/views.view.faqs.yml
+++ b/config/sync/views.view.faqs.yml
@@ -9,6 +9,7 @@ dependencies:
     - node.type.faq
     - taxonomy.vocabulary.steps
   content:
+    - 'taxonomy_term:steps:3e78e12f-7903-43fb-9f0d-2be772496823'
     - 'taxonomy_term:steps:403b1923-cf79-4734-af8c-dce9568c019c'
     - 'taxonomy_term:steps:62e1ac79-3b10-4a1b-925d-27c2be01d742'
     - 'taxonomy_term:steps:7185c829-4c0c-4f79-9df9-5cb812928c70'
@@ -18,6 +19,7 @@ dependencies:
     - 'taxonomy_term:steps:c9e1e50b-1352-474a-b3a9-b4e66bf381fe'
     - 'taxonomy_term:steps:d417486c-74e7-4406-ac91-d9be2d75e7b1'
   module:
+    - image
     - node
     - taxonomy
     - text
@@ -2381,3 +2383,126 @@ display:
       tags:
         - 'config:field.storage.node.body'
         - 'config:field.storage.node.field_image'
+  block_9:
+    display_plugin: block
+    id: block_9
+    display_title: 'FAQ Block - POV Shipments'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            faq: faq
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            22: 22
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: steps
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+        title: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      title: 'Privately Owned Vehicle (POV) Shipment FAQs'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'


### PR DESCRIPTION
Simple config to get the POV-related FAQ items requested by the client wired up.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Creates a new display within the FAQ view, filtering FAQ items by the new POV Shipments taxonomy term.
- Places the block within the Content section of block layout, immediately after the rest of the FAQ page blocks, and restricts it to appearing on the `/faqs` and `/pov` paths.

## Testing

To verify the changes proposed in this pull request…

1. Pull code and db
1. Import config
1. Create one or more FAQ items and tag each one with the POV taxonomy term
1. Each item should appear as an accordion item in a new section on both the FAQ and POV pages

## Screenshots

Partially-built section (local):
<img width="1039" alt="pov faq section partially built - local" src="https://user-images.githubusercontent.com/29130580/49903721-22c7ab00-fe36-11e8-8bd0-839936318e94.png">
