### PR TITLE
POV/SME document theming cleanup

### DIFF
--- a/config/sync/block.block.faq_section_pov_shipments.yml
+++ b/config/sync/block.block.faq_section_pov_shipments.yml
@@ -33,6 +33,6 @@ visibility:
       node: '@node.node_route_context:node'
   request_path:
     id: request_path
-    pages: "/faqs\r\n/pov"
+    pages: /faqs
     negate: false
     context_mapping: {  }

--- a/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
+++ b/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
@@ -15,4 +15,5 @@
    $size = $file->getSize();
    $variables['file_url'] = file_create_url($file->getFileUri());
    $variables['file_size'] = format_size($size);
+   $variables['file_type'] = $file->getMimeType();
  }

--- a/web/themes/custom/move_mil/scss/03-organisms/_view-sme-section.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_view-sme-section.scss
@@ -25,8 +25,8 @@
           flex-grow: 1;
           padding-right: 2rem;
 
-          &:first-child {
-            // padding-left: 75px;
+          &:only-child {
+            padding-left: 2rem;
           }
 
           .document-link {
@@ -68,6 +68,7 @@
         a {
           // background: $color-blue;
           color: $color-white;
+
           &:hover {
             cursor: default;
           }

--- a/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
+++ b/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
@@ -87,7 +87,7 @@
   {{ content.field_document_id }}
 
   <div class="doc-link-size-wrapper">
-    <a class="document-link" href="{{ file_url }}" title="Download file">{{ label.0 }}</a>
+    <a class="document-link" href="{{ file_url }}" title="View/Download {{ file_type|split('/')[1]|upper }} File">{{ label.0 }}</a>
     <span class="file-size">[{{ file_size }}]</span>
     {% if logged_in %}
       <span class="edit-item">


### PR DESCRIPTION
A few cleanup tweaks to the POV document UI, partially based on client request from demo.
Note: In prod, I also removed the fields from that POV document that they requested in the demo. No need to review, but you will need to pull that db or mimic locally if you're verifying the css tweaks.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Persists removal of POV FAQ section from POV page, matching current prod config
- Adds padding to center POV/SME document links when no other info is displayed, matching new specs for POV items
- Enhances tooltip language on document links from "Download file" to "View/Download <FILE TYPE> File"

## Testing

To verify the changes proposed in this pull request…

1. Pull code (db optional)
1. Import config and rebuild css
1. Check the document link at the bottom of the POV page.

## Screenshots

Changes implemented on local:
<img width="777" alt="pov document theme tweaks - local" src="https://user-images.githubusercontent.com/29130580/50363429-8a1de300-0539-11e9-8281-2b2b46130ad6.png">
