### PR TITLE
re-sort SME advisories by document ID (descending)

### DIFF
--- a/config/sync/views.view.sme_section.yml
+++ b/config/sync/views.view.sme_section.yml
@@ -361,6 +361,7 @@ display:
         filters: false
         filter_groups: false
         pager: false
+        sorts: false
       filter_groups:
         operator: AND
         groups:
@@ -386,6 +387,32 @@ display:
             offset: false
             offset_label: Offset
           quantity: 5
+      sorts:
+        field_document_updated_date_value:
+          id: field_document_updated_date_value
+          table: node__field_document_updated_date
+          field: field_document_updated_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+        field_document_id_value:
+          id: field_document_id_value
+          table: node__field_document_id
+          field: field_document_id_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: standard
     cache_metadata:
       max-age: -1
       contexts:
@@ -2171,11 +2198,38 @@ display:
       defaults:
         filters: false
         filter_groups: false
+        sorts: false
       filter_groups:
         operator: AND
         groups:
           1: AND
       enabled: false
+      sorts:
+        field_document_updated_date_value:
+          id: field_document_updated_date_value
+          table: node__field_document_updated_date
+          field: field_document_updated_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+        field_document_id_value:
+          id: field_document_id_value
+          table: node__field_document_id
+          field: field_document_id_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: standard
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
This PR takes care of Pivotal ticket [#163332884 - Adjust SME view configuration (Advisories) to sort by Document ID (descending)](https://www.pivotaltracker.com/story/show/163332884)

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Edits the SME Section view config covering the Advisories block to add a supplemental sort by Document ID.
- Does the same for the Archive Advisories block, though we're not using that view display anywhere at present.

## Testing

To verify the changes proposed in this pull request…

1. Pull code/db/files
1. Import config
1. Go to `/sme` and scroll to Advisories. Order should match that in the screenshot below.

## Screenshots

Local with fix:
<img width="218" alt="sme advisories sorted by id - local fixed" src="https://user-images.githubusercontent.com/29130580/51930871-83e91500-23c9-11e9-8815-f78fa9a4e1f9.png">
