### PR TITLE
SME alphabetical sort

### DIFF
--- a/config/sync/views.view.sme_section.yml
+++ b/config/sync/views.view.sme_section.yml
@@ -219,15 +219,24 @@ display:
             label: ''
           granularity: minute
           plugin_id: datetime
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
       title: Advisories
       header: {  }
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          plugin_id: text
+      empty: {  }
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
@@ -1784,6 +1793,7 @@ display:
         operator: AND
         groups:
           1: AND
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -2069,6 +2079,20 @@ display:
             label: ''
           granularity: minute
           plugin_id: datetime
+        title:
+          id: title
+          table: node_field_revision
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
This PR deals with [Pivotal ticket #163625801](https://www.pivotaltracker.com/story/show/163625801). It sort all non-advisories SME sections by alphabetical order and (as a bonus while I was at it) hides empty SME section blocks to avoid the appearance of a stray section title with nothing below it.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- See description above

## Testing

To verify the changes proposed in this pull request…

1. Pull code and import config
1. Go to `/sme`. All sections except for Advisories should now be sorted alphabetically.

## Screenshots

Example section with new sort (local):
<img width="554" alt="screen shot 2019-01-31 at 10 49 02 am" src="https://user-images.githubusercontent.com/29130580/52066915-6e99f500-2547-11e9-8ce7-10a0ab733583.png">
