### PR TITLE
links added to SME section

### DIFF
--- a/config/sync/core.entity_form_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_form_display.node.sme_document.default.yml
@@ -7,11 +7,13 @@ dependencies:
     - field.field.node.sme_document.field_document_file
     - field.field.node.sme_document.field_document_id
     - field.field.node.sme_document.field_document_updated_date
+    - field.field.node.sme_document.field_external_link
     - field.field.node.sme_document.field_sme_section
     - node.type.sme_document
   module:
     - datetime
     - file
+    - link
     - path
 id: node.sme_document.default
 targetEntityType: node
@@ -20,12 +22,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_document_archive_date:
-    weight: 12
+    weight: 13
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -46,10 +48,18 @@ content:
     type: string_textfield
     region: content
   field_document_updated_date:
-    weight: 11
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
+    region: content
+  field_external_link:
+    weight: 4
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
     region: content
   field_sme_section:
     weight: 2
@@ -59,7 +69,7 @@ content:
     region: content
   node_class:
     type: string_textfield
-    weight: 9
+    weight: 10
     region: content
     settings:
       size: 60
@@ -67,7 +77,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -75,21 +85,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 7
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 11
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 8
     region: content
     third_party_settings: {  }
   title:
@@ -102,7 +112,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 5
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/sync/core.entity_view_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.default.yml
@@ -7,11 +7,13 @@ dependencies:
     - field.field.node.sme_document.field_document_file
     - field.field.node.sme_document.field_document_id
     - field.field.node.sme_document.field_document_updated_date
+    - field.field.node.sme_document.field_external_link
     - field.field.node.sme_document.field_sme_section
     - node.type.sme_document
   module:
     - datetime
     - file
+    - link
     - user
 id: node.sme_document.default
 targetEntityType: node
@@ -51,6 +53,18 @@ content:
       format_type: short
     third_party_settings: {  }
     type: datetime_default
+    region: content
+  field_external_link:
+    weight: 6
+    label: above
+    settings:
+      trim_length: null
+      url_only: true
+      target: _blank
+      url_plain: false
+      rel: '0'
+    third_party_settings: {  }
+    type: link
     region: content
   field_sme_section:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.sme_document.teaser.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.teaser.yml
@@ -8,11 +8,13 @@ dependencies:
     - field.field.node.sme_document.field_document_file
     - field.field.node.sme_document.field_document_id
     - field.field.node.sme_document.field_document_updated_date
+    - field.field.node.sme_document.field_external_link
     - field.field.node.sme_document.field_sme_section
     - node.type.sme_document
   module:
     - datetime
     - file
+    - link
     - user
 id: node.sme_document.teaser
 targetEntityType: node
@@ -43,6 +45,18 @@ content:
     settings:
       timezone_override: ''
       date_format: j/n/Y
+    third_party_settings: {  }
+  field_external_link:
+    type: link
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
 hidden:
   field_document_archive_date: true

--- a/config/sync/field.field.node.sme_document.field_document_file.yml
+++ b/config/sync/field.field.node.sme_document.field_document_file.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: sme_document
 label: 'Document File'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.node.sme_document.field_external_link.yml
+++ b/config/sync/field.field.node.sme_document.field_external_link.yml
@@ -1,0 +1,23 @@
+uuid: 6df62345-8e4f-4ff5-a3da-10a34a1824a0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_external_link
+    - node.type.sme_document
+  module:
+    - link
+id: node.sme_document.field_external_link
+field_name: field_external_link
+entity_type: node
+bundle: sme_document
+label: 'External Link'
+description: 'The Document Title field will be used as the link''s display text.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/sync/field.storage.node.field_external_link.yml
+++ b/config/sync/field.storage.node.field_external_link.yml
@@ -1,0 +1,19 @@
+uuid: e7c644e3-423e-445d-9af7-0398aec317f5
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_external_link
+field_name: field_external_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
+++ b/web/themes/custom/move_mil/preprocess/node/node__sme_document__teaser.preprocess.inc
@@ -11,9 +11,11 @@
 
  function move_mil_preprocess_node__sme_document__teaser(&$variables){
    $node = $variables['node'];
-   $file = $node->get('field_document_file')->entity;
-   $size = $file->getSize();
-   $variables['file_url'] = file_create_url($file->getFileUri());
-   $variables['file_size'] = format_size($size);
-   $variables['file_type'] = $file->getMimeType();
+   if (!empty($node->get('field_document_file')->entity)) {
+     $file = $node->get('field_document_file')->entity;
+     $size = $file->getSize();
+     $variables['file_url'] = file_create_url($file->getFileUri());
+     $variables['file_size'] = format_size($size);
+     $variables['file_type'] = $file->getMimeType();
+   }
  }

--- a/web/themes/custom/move_mil/scss/03-organisms/_view-sme-section.scss
+++ b/web/themes/custom/move_mil/scss/03-organisms/_view-sme-section.scss
@@ -6,7 +6,7 @@
 
     li.document-item {
       padding: 1rem;
-      margin-bottom: .5rem;
+      margin-bottom: 0.5rem;
       background: $color-gray-lightest;
 
       .node--type-sme-document {
@@ -29,7 +29,7 @@
             padding-left: 2rem;
           }
 
-          .document-link {
+          .document-link, .external-link {
             font-weight: $font-bold;
           }
 
@@ -78,8 +78,8 @@
             position: absolute;
             border: 1.2rem solid $color-blue;
             border-radius: 1.2rem;
-            left: -.8rem;
-            top: -.35rem;
+            left: -0.8rem;
+            top: -0.35rem;
             z-index: -1;
           }
         }

--- a/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
+++ b/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
@@ -84,11 +84,18 @@
 {{ attach_library('classy/node') }}
 <article{{ attributes.addClass(classes) }}>
 
+
+
   {{ content.field_document_id }}
 
   <div class="doc-link-size-wrapper">
-    <a class="document-link" href="{{ file_url }}" title="View/Download {{ file_type|split('/')[1]|upper }} File">{{ label.0 }}</a>
-    <span class="file-size">[{{ file_size }}]</span>
+    {% if content.field_document_file.0 %}
+      <a class="document-link" href="{{ file_url }}" title="View/Download {{ file_type|split('/')[1]|upper }} File">{{ label.0 }}</a>
+      <span class="file-size">[{{ file_size }}]</span>
+    {% else %}
+      <a class="external-link" href="{{ content.field_external_link.0 }}" title="Open Link in New Window" target="_blank">{{ label.0 }}</a>
+    {% endif %}
+
     {% if logged_in %}
       <span class="edit-item">
         (<a href="{{ drupal_url('node/' ~ node.id ~ '/edit') }}" target="_blank">{{ 'Edit'|t }}</a>)


### PR DESCRIPTION
Adds a Link field to SME Document content type and integrates it into the view mode for SME page items. Per Pivotal ticket [#164245943](https://www.pivotaltracker.com/story/show/164245943)

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Creates a new `External Link` field on the `SME Document` content type
- Makes the `document_file` field optional
- edits the 

## Testing

To verify the changes proposed in this pull request…

1. Pull code; import config; compile theme assets; clear cache
1. Create new SME Document node with no file upload, a link url, an SME Section value of "On-line Education Series", no updated date, and an archive date in the future. This will ensure it's easy to find...
1. Go to `/sme` and scroll to the bottom. The link should be there and work as an external link to the url you entered in the previous step.


## Screenshots

<img width="980" alt="sme external link example - local" src="https://user-images.githubusercontent.com/29130580/54238663-6f7f5880-44ef-11e9-9e6d-21d9cb796ddc.png">