### PR TITLE
add additional text "Maintained by" to updated footer logo area

### DIFF
--- a/web/themes/custom/move_mil/templates/layout/page--front.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page--front.html.twig
@@ -240,7 +240,7 @@
 
         <div class="footer-agency--content">
           {% if footer_agency_name %}
-          <h3 class="{{ footer_agency_heading_class }}">{{ footer_agency_name }}</br><span class="footer-agency-name--description usa-text-small">United States Transportation Command</span></h3>
+          <h3 class="{{ footer_agency_heading_class }}"><span>{{ 'Maintained by'|t }}</span><br />{{ footer_agency_name }}</br><span class="footer-agency-name--description usa-text-small">United States Transportation Command</span></h3>
           {% endif %}
         </div>
 

--- a/web/themes/custom/move_mil/templates/layout/page.html.twig
+++ b/web/themes/custom/move_mil/templates/layout/page.html.twig
@@ -184,7 +184,7 @@
 
         <div class="footer-agency--content">
           {% if footer_agency_name %}
-          <h3 class="{{ footer_agency_heading_class }}">{{ footer_agency_name }}</br><span class="footer-agency-name--description usa-text-small">United States Transportation Command</span></h3>
+          <h3 class="{{ footer_agency_heading_class }}"><span>{{ 'Maintained by'|t }}</span><br />{{ footer_agency_name }}</br><span class="footer-agency-name--description usa-text-small">United States Transportation Command</span></h3>
           {% endif %}
         </div>
 


### PR DESCRIPTION
Additional follow-up request from Jared. See https://www.pivotaltracker.com/story/show/164551836

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Adds a line of text above TRANSCOM in the footer of both the front page and internal pages

## Testing

To verify the changes proposed in this pull request…

1. Pull code
1. View the footer on the home page to see new text
1. Do the same on any interior page

## Screenshots

### Before:
<img width="258" alt="site logo swap - footer - after" src="https://user-images.githubusercontent.com/29130580/54301019-8035da00-4594-11e9-9fd0-0f086ef40f04.png">

### After:
<img width="270" alt="site logo swap with new text line - after" src="https://user-images.githubusercontent.com/29130580/54301004-7a3ff900-4594-11e9-8194-1e5df36a78d5.png">
