### PR TITLE
Use other fields from the xml to find the geolocation of the office

### DIFF
--- a/web/modules/custom/locations/src/Form/ManagerForm.php
+++ b/web/modules/custom/locations/src/Form/ManagerForm.php
@@ -249,7 +249,8 @@ class ManagerForm extends ConfigFormBase {
       $ignored = $form_state->getValue(['filters_fieldset', 'filter']);
       $xml = $this->reader->parse($filePath, $ignored);
       $this->updateLocations($xml);
-      $this->deleteOldLocations($xml);
+      // Removing since there's a bug with this, and we have the exception list.
+      // $this->deleteOldLocations($xml);
     }
     catch (\Exception $e) {
       $this->messenger()->addError('Error: ' . $e->getMessage());

--- a/web/modules/custom/locations/src/Service/Writer.php
+++ b/web/modules/custom/locations/src/Service/Writer.php
@@ -272,7 +272,7 @@ class Writer {
     $node->set('field_location_telephone', $phone_references);
     $node->save();
   }
-  
+
   /**
    * Update Drupal Location with the XML phone content.
    *

--- a/web/modules/custom/locations/src/Service/Writer.php
+++ b/web/modules/custom/locations/src/Service/Writer.php
@@ -38,7 +38,7 @@ class Writer {
       Writer::updateLocationPhones($node, $nodeData['phones']);
     }
     // Update or add geolocation.
-    $error = Writer::updateGeolocation($node, $googleApi);
+    $error = Writer::updateGeolocation($node, $nodeData, $googleApi);
     if (!empty($error)) {
       \Drupal::messenger()->addWarning($error);
     }
@@ -272,12 +272,14 @@ class Writer {
     $node->set('field_location_telephone', $phone_references);
     $node->save();
   }
-
+  
   /**
    * Update Drupal Location with the XML phone content.
    *
    * @param \Drupal\node\Entity\Node $node
    *   Drupal Location entity.
+   * @param array $nodeData
+   *   The source data from XML office.
    * @param string $googleApi
    *   Environment Google API key.
    *
@@ -286,9 +288,18 @@ class Writer {
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  private static function updateGeolocation(Node $node, $googleApi) {
-    $title = $node->getTitle();
-    $request = "https://maps.google.com/maps/api/geocode/json?address={$title}&key=$googleApi";
+  private static function updateGeolocation(Node $node, array $nodeData, $googleApi) {
+    $title = $nodeData['name'];
+    $country = $nodeData['address']['country_code'];
+    $zipcode = $nodeData['address']['postal_code'];
+    $city = $nodeData['address']['locality'];
+    // String to send to Google Maps API.
+    $address = "{$zipcode}, {$city}, {$country}";
+    // Don't use zipcode outside the US. Some don't have the correct format.
+    if ($country != 'US') {
+      $address = "{$city}, {$country}";
+    }
+    $request = "https://maps.google.com/maps/api/geocode/json?address={$address}&key=$googleApi";
     $client = new Client();
     try {
       $res = $client->request('GET', $request);


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- Uses "{$zipcode}, {$city}, {$country}" for US offices
- Uses "{$city}, {$country}" for non-US offices
- Remove the usage of office name, since is not correct for some offices.

## Testing

To verify the changes proposed in this pull request…

1. Pull the changes
1. Use the uploader
1. Check offices on the locator maps tool

## Screenshots

![ApproximateGeolocations](https://user-images.githubusercontent.com/37001835/54447575-2cf09280-4720-11e9-9869-c3a8036c1f0f.png)
