### PR TITLE
hide all active SME Section view blocks with no content

### DIFF
--- a/config/sync/views.view.sme_section.yml
+++ b/config/sync/views.view.sme_section.yml
@@ -423,6 +423,7 @@ display:
           expose:
             label: ''
           plugin_id: standard
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -1389,6 +1390,7 @@ display:
         operator: AND
         groups:
           1: AND
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -1524,6 +1526,7 @@ display:
         operator: AND
         groups:
           1: AND
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -1659,6 +1662,7 @@ display:
         operator: AND
         groups:
           1: AND
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -1825,6 +1829,7 @@ display:
         operator: AND
         groups:
           1: AND
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -2096,6 +2101,7 @@ display:
         operator: AND
         groups:
           1: AND
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -2291,6 +2297,7 @@ display:
           entity_type: node
           entity_field: title
           plugin_id: standard
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Triages a minor residual bug on the SME page that has already been fixed on Prod. This update simply persists that configuration change.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).


## Screenshots

Before (staging):
<img width="1018" alt="hide empty SME view blocks - staging unfixed" src="https://user-images.githubusercontent.com/29130580/54622205-8cf87900-4a3f-11e9-97c1-d6dbe4475a0b.png">

After (prod & local):
<img width="1002" alt="hide empty SME view blocks - prod fixed" src="https://user-images.githubusercontent.com/29130580/54622337-cfba5100-4a3f-11e9-99c8-ad22a1078b7b.png">
