### PR TITLE
Geolocate only Transportation offices, by complete country name

### DIFF
--- a/web/modules/custom/locations/src/Service/Reader.php
+++ b/web/modules/custom/locations/src/Service/Reader.php
@@ -84,6 +84,9 @@ class Reader {
       'administrative_area' => (string) $officeInfo->{$locType . 'STATE'},
       'postal_code' => (string) $officeInfo->{$locType . 'ZIP'},
     ];
+    if (!$isPPSO) {
+      $node['address']['country_name'] = (string) $officeInfo->CNSL_CTRY_NM;
+    }
     // Get XML file email elements.
     $xpath = "LIST_G_{$locType}EMAIL_ORG_ID/G_{$locType}EMAIL_ORG_ID/LIST_G_{$locType}EMAIL/G_";
     $xpath = $xpath . ($isPPSO ? 'ppso_email' : 'CNSL_EMAIL');

--- a/web/modules/custom/locations/src/Service/Writer.php
+++ b/web/modules/custom/locations/src/Service/Writer.php
@@ -37,10 +37,12 @@ class Writer {
     if (!empty($nodeData['phones'])) {
       Writer::updateLocationPhones($node, $nodeData['phones']);
     }
-    // Update or add geolocation.
-    $error = Writer::updateGeolocation($node, $nodeData, $googleApi);
-    if (!empty($error)) {
-      \Drupal::messenger()->addWarning($error);
+    // Update or add geolocation if transportation office.
+    if (!$nodeData['isPPSO']) {
+      $error = Writer::updateGeolocation($node, $nodeData, $googleApi);
+      if (!empty($error)) {
+        \Drupal::messenger()->addWarning($error);
+      }
     }
   }
 
@@ -290,7 +292,7 @@ class Writer {
    */
   private static function updateGeolocation(Node $node, array $nodeData, $googleApi) {
     $title = $nodeData['name'];
-    $country = $nodeData['address']['country_code'];
+    $country = empty($nodeData['address']['country_name']) ? $nodeData['address']['country_code'] : $nodeData['address']['country_name'];
     $zipcode = $nodeData['address']['postal_code'];
     $city = $nodeData['address']['locality'];
     // String to send to Google Maps API.


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [ ] run the application locally (`make up`) and verified that my changes behave as expected.
- [ ] run static behat test suite (`circleci build --job behat`) against my changes.
- [ ] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [ ] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [ ] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request…

- Use complete country name instead of country code to add in the geolocate API call, since some locations within the XML come without the country code.
- Limit geolocalization for transportation offices only.

## Testing

To verify the changes proposed in this pull request…

1. Pull branch
1. Use locations uploader tool to upload an XML file.
1. When looking for Illinois you should not see an office from Russia.
1. When looking for Russia, you should see the "NONE" location, which is the USA consulate on Russia.
