### PR TITLE
Initialize locations config with empty array

### DIFF
--- a/web/modules/custom/locations/src/Form/ManagerForm.php
+++ b/web/modules/custom/locations/src/Form/ManagerForm.php
@@ -104,7 +104,12 @@ class ManagerForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(static::SETTINGS);
-    $configExclusions = $config->get('exclusions');
+    if (!empty($config->get('exclusions'))) {
+      $configExclusions = $config->get('exclusions');
+    }
+    else {
+      $configExclusions = [];
+    }
 
     $form['#tree'] = TRUE;
 


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request…

- Initialize locations config with an empty array

## Testing

To verify the changes proposed in this pull request…

1. You shouldn't see this error "Warning: count(): Parameter must be an array or an object that implements Countable in Drupal\locations\Form\ManagerForm->buildForm() (line 132 of modules/custom/locations/src/Form/ManagerForm.php)."
