### PR TITLE
add UNITED STATES to validate is a US city

### DIFF
--- a/web/modules/custom/locations/src/Service/Writer.php
+++ b/web/modules/custom/locations/src/Service/Writer.php
@@ -264,7 +264,7 @@ class Writer {
     // String to send to Google Maps API.
     $address = "{$zipcode}, {$city}, {$country}";
     // Don't use zipcode outside the US. Some don't have the correct format.
-    if ($country != 'US') {
+    if ($country != 'UNITED STATES' && $country != 'US') {
       $address = "{$city}, {$country}";
     }
     $request = "https://maps.google.com/maps/api/geocode/json?address={$address}&key=$googleApi";


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- Add 'UNITED STATES' to the validation to know if the city is a US city or other county city. As opposed to us 'US'.

## Testing

To verify the changes proposed in this pull request…

1. BLUE GRASS ARMY DEPOT should be geolocated on Kentucky as opposed to Virginia.

## Screenshots

![Screen Shot 2019-06-06 at 4 00 48 PM](https://user-images.githubusercontent.com/37001835/59076594-edf85600-88a4-11e9-81e4-689e8eb67218.png)
