### PR TITLE
set up cloud watch to gather nginx access logs

### DIFF
--- a/.ebextensions/cwl-webrequest-metrics.config
+++ b/.ebextensions/cwl-webrequest-metrics.config
@@ -18,18 +18,18 @@
 ##   CWLHttp4xxPercent - this alarm fires if the percentage of calls returning
 ##                        4xx response codes > 10%    
 ##
-##  Note - this demo works with apache containers that are using the default common log format
+##  Note - this demo works with nginx containers that are using the default common log format
 ##      (python and php ruby containers do this - tomcat does not)
 ###############################################################################
 
 
-# Apache access log pattern:
+# nginx access log pattern:
 ## "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\""
 ## remote_host  remote_logname  remote_user  time_received "request" status response_size "referrer" "user-agent"
 Mappings:
   CWLogs:
     WebRequestLogGroup:
-      LogFile: "/var/log/httpd/access_log"
+      LogFile: "/var/log/nginx/access.log"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
     FilterPatterns:
       Http4xxMetricFilter: "[..., status=4*, size, referer, agent]"  
@@ -65,9 +65,9 @@ Resources :
         CWLogsAgentConfigSetup:
           files:
             ## any .conf file put into /tmp/cwlogs/conf.d will be added to the cwlogs config (see cwl-agent.config)
-            "/tmp/cwlogs/conf.d/apache-access.conf":
+            "/tmp/cwlogs/conf.d/nginx-access.conf":
               content : |
-                [apache-access_log]
+                [nginx-access_log]
                 file = `{"Fn::FindInMap":["CWLogs", "WebRequestLogGroup", "LogFile"]}`
                 log_group_name = `{ "Ref" : "AWSEBCloudWatchLogs8832c8d3f1a54c238a40e36f31ef55a0WebRequestLogGroup" }`
                 log_stream_name = {instance_id}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -161,10 +161,6 @@ RUN set -x \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
 
-# forward request and error logs to docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-	&& ln -sf /dev/stderr /var/log/nginx/error.log
-
 WORKDIR /var/www/html
 RUN apt-get update && apt-get install -y --no-install-recommends \
     mysql-client \

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -93,7 +93,7 @@ http {
 
     server {
         listen		80 default_server;
-        listen          [::]:80 default_server;
+        listen      [::]:80 default_server;
         root		/var/www/html/web;
         index		index.php index.html index.htm;
         server_name	localhost;


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request…

- pulls nginx logs into cloud watch logs

## Testing

To verify the changes proposed in this pull request…

1. deploy new version to AWS
2. check that the "Logs" page contains access.log entries
