### PR TITLE
increased php memory limit and added supervisorctl to control supervi…

### DIFF
--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,3 +1,3 @@
 post_max_size = 24M
 upload_max_filesize = 20M
-memory_limit = 512M
+memory_limit = 1024M

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -3,6 +3,13 @@ nodaemon = true
 logfile = /dev/stdout
 logfile_maxbytes = 0
 
+[unix_http_server]
+file = /var/run/supervisor.sock
+chmod = 0777
+
+[supervisorctl]
+serverurl = unix:///var/run/supervisor.sock
+
 [program:php-fpm]
 command = /usr/local/sbin/php-fpm -F
 autostart = true


### PR DESCRIPTION


Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request…

- Increases the php memory limit
- allows supervisord to be controlled by supervisorctl

## Testing

To verify the changes proposed in this pull request…

1. Restart the docker container
2. check phpinfo() that the memory limit has increased to 1024M
3. Verify that php-fpm and/or nginx can be restarted with supervisorctl